### PR TITLE
chore(deps): Update `certifi` from 2022.6.15 to 2023.7.22

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ bumpversion==0.5.3
     # via -r requirements-dev.in
 cachetools==5.3.1
     # via tox
-certifi==2022.6.15
+certifi==2023.7.22
     # via
     #   -c requirements.txt
     #   requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ asgiref==3.5.2
     # via django
 attrs==20.3.0
     # via jsonschema
-certifi==2022.6.15
+certifi==2023.7.22
     # via signxml
 cffi==1.15.1
     # via cryptography


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/certifi/2023.7.22/)
- [Commits](https://github.com/certifi/python-certifi/compare/2022.06.15...2023.07.22)