### PR TITLE
Fix type checking of Setuptools configuration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -31,6 +31,9 @@ ignore_missing_imports = True
 [mypy-rest_framework.*]
 ignore_missing_imports = True
 
+[mypy-setuptools.*]
+ignore_missing_imports = True
+
 [pydantic-mypy]
 init_forbid_extra = True
 init_typed = True

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from typing import Sequence
 from setuptools import find_packages, setup
 
 
-def get_version(*file_paths: Sequence[str]) -> str:
+def get_version(*file_paths: str) -> str:
     filename = os.path.join(os.path.dirname(__file__), *file_paths)
     version_file = open(filename).read()
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
@@ -37,9 +37,9 @@ extras_requirements = {
     'djangorestframework': ['djangorestframework>=3.10.3,<3.15'],
 }
 
-setup_requirements = []
+setup_requirements: Sequence[str] = []
 
-test_requirements = [
+test_requirements: Sequence[str] = [
     # note: include here only packages **imported** in test code (e.g. 'requests-mock'), NOT those
     #   like 'coverage' or 'tox'.
 ]


### PR DESCRIPTION
- Fix incorrect type annotation of `get_version()` in `setup.py`.
- Add missing type annotations to `setup_requirements` and `test_requirements` in `setup.py`.
- Update Mypy configuration to ignore missing imports for `setuptools`.