### PR TITLE
chore(deps): Update `typing-extensions` from 4.3.0 to 4.7.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -134,7 +134,7 @@ types-pyopenssl==23.2.0.2
     # via -r requirements-dev.in
 types-pytz==2023.3.0.1
     # via -r requirements-dev.in
-typing-extensions==4.3.0
+typing-extensions==4.7.1
     # via
     #   -c requirements.txt
     #   black

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ signxml==3.2.0
     # via -r requirements.in
 sqlparse==0.4.4
     # via django
-typing-extensions==4.3.0
+typing-extensions==4.7.1
     # via pydantic
 zipp==3.8.1
     # via


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/typing-extensions/4.7.1/)
- [Release notes](https://github.com/python/typing_extensions/releases/tag/4.7.1)
- [Changelog](https://github.com/python/typing_extensions/blob/4.7.1/CHANGELOG.md#release-471-july-2-2023)
- [Commits](https://github.com/python/typing_extensions/compare/4.3.0...4.7.1)