### PR TITLE
Update pydantic from 1.10.12 to 2.3.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ importlib-metadata==6.1.0
 jsonschema==4.17.3
 lxml==4.9.2
 marshmallow==3.19.0
-pydantic==1.10.12
+pydantic==2.3.0
 pyOpenSSL==23.2.0
 pytz==2023.3
 signxml==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --strip-extras requirements.in
 #
+annotated-types==0.5.0
+    # via pydantic
 asgiref==3.5.2
     # via django
 attrs==20.3.0
@@ -43,8 +45,10 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pycparser==2.20
     # via cffi
-pydantic==1.10.12
+pydantic==2.3.0
     # via -r requirements.in
+pydantic-core==2.6.3
+    # via pydantic
 pyopenssl==23.2.0
     # via
     #   -r requirements.in
@@ -61,7 +65,10 @@ signxml==3.2.0
 sqlparse==0.4.4
     # via django
 typing-extensions==4.7.1
-    # via pydantic
+    # via
+    #   annotated-types
+    #   pydantic
+    #   pydantic-core
 zipp==3.8.1
     # via
     #   importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     'jsonschema>=3.1.1',
     'lxml>=4.6.5,<5',
     'marshmallow>=3,<4',
-    'pydantic>=1.6.2,!=1.7.*,!=1.8.*,!=1.9.*',
+    'pydantic>=2.3.0,!=1.7.*,!=1.8.*,!=1.9.*',
     'pyOpenSSL>=22.0.0',
     'pytz>=2019.3',
     'signxml>=3.1.0',

--- a/src/cl_sii/dte/data_models.py
+++ b/src/cl_sii/dte/data_models.py
@@ -21,7 +21,7 @@ import dataclasses
 from datetime import date, datetime
 from typing import Mapping, Optional, Sequence
 
-import pydantic
+import pydantic.v1
 
 import cl_sii.contribuyente.constants
 import cl_sii.rut.constants
@@ -98,7 +98,7 @@ def validate_non_empty_bytes(value: bytes) -> None:
         raise ValueError("Bytes value length is 0.")
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -165,14 +165,14 @@ class DteNaturalKey:
     # Validators
     ###########################################################################
 
-    @pydantic.validator('folio')
+    @pydantic.v1.validator('folio')
     def validate_folio(cls, v: object) -> object:
         if isinstance(v, int):
             validate_dte_folio(v)
         return v
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -214,7 +214,7 @@ class DteDataL0(DteNaturalKey):
         return DteNaturalKey(emisor_rut=self.emisor_rut, tipo_dte=self.tipo_dte, folio=self.folio)
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -322,7 +322,7 @@ class DteDataL1(DteDataL0):
     # Validators
     ###########################################################################
 
-    @pydantic.validator('monto_total')
+    @pydantic.v1.validator('monto_total')
     def validate_monto_total(cls, v: object, values: Mapping[str, object]) -> object:
         tipo_dte = values.get('tipo_dte')
 
@@ -332,7 +332,7 @@ class DteDataL1(DteDataL0):
         return v
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -433,38 +433,38 @@ class DteDataL2(DteDataL1):
     # Validators
     ###########################################################################
 
-    @pydantic.validator('emisor_razon_social', 'receptor_razon_social')
+    @pydantic.v1.validator('emisor_razon_social', 'receptor_razon_social')
     def validate_contribuyente_razon_social(cls, v: object) -> object:
         if isinstance(v, str):
             validate_contribuyente_razon_social(v)
         return v
 
-    @pydantic.validator('firma_documento_dt')
+    @pydantic.v1.validator('firma_documento_dt')
     def validate_datetime_tz(cls, v: object) -> object:
         if isinstance(v, datetime):
             tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
         return v
 
-    @pydantic.validator('signature_value', 'signature_x509_cert_der')
+    @pydantic.v1.validator('signature_value', 'signature_x509_cert_der')
     def validate_non_empty_bytes(cls, v: object) -> object:
         if isinstance(v, bytes):
             validate_non_empty_bytes(v)
         return v
 
-    @pydantic.validator('emisor_giro', 'emisor_email', 'receptor_email')
+    @pydantic.v1.validator('emisor_giro', 'emisor_email', 'receptor_email')
     def validate_no_leading_or_trailing_whitespace_characters(cls, v: object) -> object:
         if isinstance(v, str):
             validate_clean_str(v)
         return v
 
-    @pydantic.validator('emisor_giro', 'emisor_email', 'receptor_email')
+    @pydantic.v1.validator('emisor_giro', 'emisor_email', 'receptor_email')
     def validate_non_empty_stripped_str(cls, v: object) -> object:
         if isinstance(v, str):
             validate_non_empty_str(v)
         return v
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -579,7 +579,7 @@ class DteXmlReferencia:
     # Validators
     ###########################################################################
 
-    @pydantic.validator('numero_linea_ref')
+    @pydantic.v1.validator('numero_linea_ref')
     def validate_numero_linea_ref(cls, value: int) -> int:
         if (
             constants.DTE_REFERENCIA_LINE_NUMBER_MIN_VALUE
@@ -595,7 +595,7 @@ class DteXmlReferencia:
             value,
         )
 
-    @pydantic.validator('tipo_documento_ref')
+    @pydantic.v1.validator('tipo_documento_ref')
     def validate_tipo_documento_ref(cls, value: str) -> str:
         if 1 <= len(value) <= 3:
             return value
@@ -604,13 +604,13 @@ class DteXmlReferencia:
             "The length of 'tipo_documento_ref' must be a value between 1 and 3", value
         )
 
-    @pydantic.validator('ind_global')
+    @pydantic.v1.validator('ind_global')
     def validate_ind_global(cls, value: int | None) -> int | None:
         if value and value != 1:
             raise ValueError("Only the value '1' is valid for the field 'ind_global'", value)
         return value
 
-    @pydantic.validator('folio_ref')
+    @pydantic.v1.validator('folio_ref')
     def validate_folio_ref(cls, value: str) -> str:
         if (
             constants.DTE_REFERENCIA_FOLIO_MIN_LENGTH
@@ -626,7 +626,7 @@ class DteXmlReferencia:
             value,
         )
 
-    @pydantic.validator('fecha_ref')
+    @pydantic.v1.validator('fecha_ref')
     def validate_fecha_ref(cls, value: date) -> date:
         if (
             value < constants.DTE_REFERENCIA_FECHA_NOT_BEFORE
@@ -641,7 +641,7 @@ class DteXmlReferencia:
 
         return value
 
-    @pydantic.validator('razon_ref')
+    @pydantic.v1.validator('razon_ref')
     def validate_razon_ref(cls, value: str | None) -> str | None:
         if value and len(value) > constants.DTE_REFERENCIA_RAZON_MAX_LENGTH:
             raise ValueError(
@@ -653,7 +653,7 @@ class DteXmlReferencia:
         return value
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -781,37 +781,37 @@ class DteXmlData(DteDataL1):
     # Validators
     ###########################################################################
 
-    @pydantic.validator('emisor_razon_social', 'receptor_razon_social')
+    @pydantic.v1.validator('emisor_razon_social', 'receptor_razon_social')
     def validate_contribuyente_razon_social(cls, v: object) -> object:
         if isinstance(v, str):
             validate_contribuyente_razon_social(v)
         return v
 
-    @pydantic.validator('firma_documento_dt')
+    @pydantic.v1.validator('firma_documento_dt')
     def validate_datetime_tz(cls, v: object) -> object:
         if isinstance(v, datetime):
             tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
         return v
 
-    @pydantic.validator('signature_value', 'signature_x509_cert_der')
+    @pydantic.v1.validator('signature_value', 'signature_x509_cert_der')
     def validate_non_empty_bytes(cls, v: object) -> object:
         if isinstance(v, bytes):
             validate_non_empty_bytes(v)
         return v
 
-    @pydantic.validator('emisor_giro', 'emisor_email', 'receptor_email')
+    @pydantic.v1.validator('emisor_giro', 'emisor_email', 'receptor_email')
     def validate_no_leading_or_trailing_whitespace_characters(cls, v: object) -> object:
         if isinstance(v, str):
             validate_clean_str(v)
         return v
 
-    @pydantic.validator('emisor_giro', 'emisor_email', 'receptor_email')
+    @pydantic.v1.validator('emisor_giro', 'emisor_email', 'receptor_email')
     def validate_non_empty_stripped_str(cls, v: object) -> object:
         if isinstance(v, str):
             validate_non_empty_str(v)
         return v
 
-    @pydantic.validator('referencias')
+    @pydantic.v1.validator('referencias')
     def validate_referencias_numero_linea_ref_order(cls, v: object) -> object:
         if isinstance(v, Sequence):
             for idx, referencia in enumerate(v, start=1):
@@ -819,7 +819,7 @@ class DteXmlData(DteDataL1):
                     raise ValueError("items must be ordered according to their 'numero_linea_ref'")
         return v
 
-    @pydantic.root_validator(skip_on_failure=True)
+    @pydantic.v1.root_validator(skip_on_failure=True)
     def validate_referencias_rut_otro_is_consistent_with_tipo_dte(
         cls,
         values: Mapping[str, object],
@@ -842,7 +842,7 @@ class DteXmlData(DteDataL1):
 
         return values
 
-    @pydantic.root_validator(skip_on_failure=True)
+    @pydantic.v1.root_validator(skip_on_failure=True)
     def validate_referencias_rut_otro_is_consistent_with_emisor_rut(
         cls,
         values: Mapping[str, object],
@@ -861,7 +861,7 @@ class DteXmlData(DteDataL1):
 
         return values
 
-    @pydantic.root_validator(skip_on_failure=True)
+    @pydantic.v1.root_validator(skip_on_failure=True)
     def validate_referencias_codigo_ref_is_consistent_with_tipo_dte(
         cls,
         values: Mapping[str, object],

--- a/src/cl_sii/dte/parse.py
+++ b/src/cl_sii/dte/parse.py
@@ -26,7 +26,7 @@ import os
 from datetime import date, datetime
 from typing import Mapping, Optional, Sequence, Tuple
 
-import pydantic
+import pydantic.v1
 
 from cl_sii.libs import encoding_utils, tz_utils, xml_utils
 from cl_sii.libs.xml_utils import XmlElement, XmlElementTree
@@ -570,7 +570,7 @@ def _validate_rut(v: object) -> object:
     return v
 
 
-class _DteXmlReferenciaParser(pydantic.BaseModel):
+class _DteXmlReferenciaParser(pydantic.v1.BaseModel):
     """
     Parser for ``/Documento/Referencia``.
     """
@@ -579,7 +579,7 @@ class _DteXmlReferenciaParser(pydantic.BaseModel):
         allow_mutation = False
         anystr_strip_whitespace = True
         arbitrary_types_allowed = True
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
 
     ###########################################################################
     # Fields
@@ -636,7 +636,7 @@ class _DteXmlReferenciaParser(pydantic.BaseModel):
     # Validators
     ###########################################################################
 
-    _validate_rut = pydantic.validator(
+    _validate_rut = pydantic.v1.validator(
         'rut_otro',
         pre=True,
         allow_reuse=True,

--- a/src/cl_sii/rcv/data_models.py
+++ b/src/cl_sii/rcv/data_models.py
@@ -10,7 +10,7 @@ import logging
 from datetime import date, datetime
 from typing import ClassVar, Mapping, Optional
 
-import pydantic
+import pydantic.v1
 
 import cl_sii.dte.data_models
 from cl_sii.base.constants import SII_OFFICIAL_TZ
@@ -22,7 +22,7 @@ from .constants import RcEstadoContable, RcvKind, RcvTipoDocto
 logger = logging.getLogger(__name__)
 
 
-@pydantic.dataclasses.dataclass(frozen=True)
+@pydantic.v1.dataclasses.dataclass(frozen=True)
 class PeriodoTributario:
     ###########################################################################
     # constants
@@ -41,14 +41,14 @@ class PeriodoTributario:
     # Validators
     ###########################################################################
 
-    @pydantic.validator('year')
+    @pydantic.v1.validator('year')
     def validate_year(cls, v: object) -> object:
         if isinstance(v, int) and v < 1900:
             # 1900 si an arbitrary number but it more useful than checking not < 1.
             raise ValueError("Value is out of the valid range for 'year'.")
         return v
 
-    @pydantic.validator('month')
+    @pydantic.v1.validator('month')
     def validate_month(cls, v: object) -> object:
         if isinstance(v, int):
             if v < 1 or v > 12:
@@ -97,7 +97,7 @@ class PeriodoTributario:
         )
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -161,19 +161,19 @@ class RcvDetalleEntry:
     # Validators
     ###########################################################################
 
-    @pydantic.validator('folio')
+    @pydantic.v1.validator('folio')
     def validate_folio(cls, v: object) -> object:
         if isinstance(v, int):
             cl_sii.dte.data_models.validate_dte_folio(v)
         return v
 
-    @pydantic.validator('fecha_recepcion_dt')
+    @pydantic.v1.validator('fecha_recepcion_dt')
     def validate_datetime_tz(cls, v: object) -> object:
         if isinstance(v, datetime):
             tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
         return v
 
-    @pydantic.root_validator(skip_on_failure=True)
+    @pydantic.v1.root_validator(skip_on_failure=True)
     def validate_rcv_kind_is_consistent_with_rc_estado_contable(
         cls,
         values: Mapping[str, object],
@@ -233,7 +233,7 @@ class RcvDetalleEntry:
         return dte_data
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -274,20 +274,20 @@ class RvDetalleEntry(RcvDetalleEntry):
     # Validators
     ###########################################################################
 
-    @pydantic.validator('receptor_razon_social')
+    @pydantic.v1.validator('receptor_razon_social')
     def validate_contribuyente_razon_social(cls, v: object) -> object:
         if isinstance(v, str):
             cl_sii.dte.data_models.validate_contribuyente_razon_social(v)
         return v
 
-    @pydantic.validator('fecha_acuse_dt', 'fecha_reclamo_dt')
+    @pydantic.v1.validator('fecha_acuse_dt', 'fecha_reclamo_dt')
     def validate_datetime_tz(cls, v: object) -> object:
         if isinstance(v, datetime):
             tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
         return v
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -325,20 +325,20 @@ class RcRegistroDetalleEntry(RcvDetalleEntry):
     # Validators
     ###########################################################################
 
-    @pydantic.validator('emisor_razon_social')
+    @pydantic.v1.validator('emisor_razon_social')
     def validate_contribuyente_razon_social(cls, v: object) -> object:
         if isinstance(v, str):
             cl_sii.dte.data_models.validate_contribuyente_razon_social(v)
         return v
 
-    @pydantic.validator('fecha_acuse_dt')
+    @pydantic.v1.validator('fecha_acuse_dt')
     def validate_datetime_tz(cls, v: object) -> object:
         if isinstance(v, datetime):
             tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
         return v
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -358,7 +358,7 @@ class RcNoIncluirDetalleEntry(RcRegistroDetalleEntry):
     RC_ESTADO_CONTABLE = RcEstadoContable.NO_INCLUIR
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -400,20 +400,20 @@ class RcReclamadoDetalleEntry(RcvDetalleEntry):
     # Validators
     ###########################################################################
 
-    @pydantic.validator('emisor_razon_social')
+    @pydantic.v1.validator('emisor_razon_social')
     def validate_contribuyente_razon_social(cls, v: object) -> object:
         if isinstance(v, str):
             cl_sii.dte.data_models.validate_contribuyente_razon_social(v)
         return v
 
-    @pydantic.validator('fecha_reclamo_dt')
+    @pydantic.v1.validator('fecha_reclamo_dt')
     def validate_datetime_tz(cls, v: object) -> object:
         if isinstance(v, datetime):
             tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
         return v
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -441,7 +441,7 @@ class RcPendienteDetalleEntry(RcvDetalleEntry):
     # Validators
     ###########################################################################
 
-    @pydantic.validator('emisor_razon_social')
+    @pydantic.v1.validator('emisor_razon_social')
     def validate_contribuyente_razon_social(cls, v: object) -> object:
         if isinstance(v, str):
             cl_sii.dte.data_models.validate_contribuyente_razon_social(v)

--- a/src/cl_sii/rtc/data_models.py
+++ b/src/cl_sii/rtc/data_models.py
@@ -23,7 +23,7 @@ import dataclasses
 from datetime import date, datetime
 from typing import Any, ClassVar, Mapping, Optional
 
-import pydantic
+import pydantic.v1
 
 from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.dte import data_models as dte_data_models
@@ -79,7 +79,7 @@ def validate_cesion_and_dte_montos(cesion_value: int, dte_value: int) -> None:
         raise ValueError('Value of "cesión" must be <= value of DTE.', cesion_value, dte_value)
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -140,20 +140,20 @@ class CesionNaturalKey:
     # Validators
     ###########################################################################
 
-    @pydantic.validator('dte_key')
+    @pydantic.v1.validator('dte_key')
     def validate_dte_tipo_dte(cls, v: object) -> object:
         if isinstance(v, dte_data_models.DteNaturalKey):
             validate_cesion_dte_tipo_dte(v.tipo_dte)
         return v
 
-    @pydantic.validator('seq')
+    @pydantic.v1.validator('seq')
     def validate_seq(cls, v: object) -> object:
         if isinstance(v, int):
             validate_cesion_seq(v)
         return v
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -245,19 +245,19 @@ class CesionAltNaturalKey:
     # Validators
     ###########################################################################
 
-    @pydantic.validator('dte_key')
+    @pydantic.v1.validator('dte_key')
     def validate_dte_tipo_dte(cls, v: object) -> object:
         if isinstance(v, dte_data_models.DteNaturalKey):
             validate_cesion_dte_tipo_dte(v.tipo_dte)
         return v
 
-    @pydantic.validator('fecha_cesion_dt')
+    @pydantic.v1.validator('fecha_cesion_dt')
     def validate_datetime_tz(cls, v: object) -> object:
         if isinstance(v, datetime):
             tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
         return v
 
-    @pydantic.validator('fecha_cesion_dt')
+    @pydantic.v1.validator('fecha_cesion_dt')
     def truncate_fecha_cesion_dt_to_minutes(cls, v: object) -> object:
         if isinstance(v, datetime):
             if v.second != 0:
@@ -267,7 +267,7 @@ class CesionAltNaturalKey:
         return v
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -390,26 +390,26 @@ class CesionL0:
     # Validators
     ###########################################################################
 
-    @pydantic.validator('dte_key')
+    @pydantic.v1.validator('dte_key')
     def validate_dte_tipo_dte(cls, v: object) -> object:
         if isinstance(v, dte_data_models.DteNaturalKey):
             validate_cesion_dte_tipo_dte(v.tipo_dte)
         return v
 
-    @pydantic.validator('seq')
+    @pydantic.v1.validator('seq')
     def validate_seq(cls, v: object) -> object:
         if isinstance(v, int):
             validate_cesion_seq(v)
         return v
 
-    @pydantic.validator('fecha_cesion_dt')
+    @pydantic.v1.validator('fecha_cesion_dt')
     def validate_datetime_tz(cls, v: object) -> object:
         if isinstance(v, datetime):
             tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
         return v
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -508,13 +508,13 @@ class CesionL1(CesionL0):
 
     # TODO: Validate value of 'fecha_cesion_dt' in relation to the DTE data.
 
-    @pydantic.validator('monto_cedido')
+    @pydantic.v1.validator('monto_cedido')
     def validate_monto_cedido(cls, v: object) -> object:
         if isinstance(v, int):
             validate_cesion_monto(v)
         return v
 
-    @pydantic.root_validator(skip_on_failure=True)
+    @pydantic.v1.root_validator(skip_on_failure=True)
     def validate_monto_cedido_does_not_exceed_dte_monto_total(
         cls,
         values: Mapping[str, object],
@@ -528,7 +528,7 @@ class CesionL1(CesionL0):
         return values
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -696,7 +696,7 @@ class CesionL2(CesionL1):
 
     # TODO: Validate value of 'fecha_ultimo_vencimiento' in relation to the DTE data.
 
-    @pydantic.validator(
+    @pydantic.v1.validator(
         'fecha_cesion_dt',
         'fecha_firma_dt',
     )
@@ -705,7 +705,7 @@ class CesionL2(CesionL1):
             tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
         return v
 
-    @pydantic.validator(
+    @pydantic.v1.validator(
         'cedente_razon_social',
         'cesionario_razon_social',
         'dte_emisor_razon_social',
@@ -716,7 +716,7 @@ class CesionL2(CesionL1):
             dte_data_models.validate_contribuyente_razon_social(v)
         return v
 
-    @pydantic.root_validator(skip_on_failure=True)
+    @pydantic.v1.root_validator(skip_on_failure=True)
     def validate_dte_data_l2(cls, values: Mapping[str, Any]) -> Mapping[str, object]:
         dte_key = values['dte_key']
         try:

--- a/src/cl_sii/rtc/data_models_aec.py
+++ b/src/cl_sii/rtc/data_models_aec.py
@@ -9,7 +9,7 @@ import dataclasses
 from datetime import date, datetime
 from typing import ClassVar, Mapping, Optional, Sequence, Tuple
 
-import pydantic
+import pydantic.v1
 
 from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.dte import data_models as dte_data_models
@@ -18,7 +18,7 @@ from cl_sii.rut import Rut
 from . import data_models
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -307,25 +307,25 @@ class CesionAecXml:
     # Validators
     ###########################################################################
 
-    @pydantic.validator('dte')
+    @pydantic.v1.validator('dte')
     def validate_dte_tipo_dte(cls, v: object) -> object:
         if isinstance(v, dte_data_models.DteDataL0):
             data_models.validate_cesion_dte_tipo_dte(v.tipo_dte)
         return v
 
-    @pydantic.validator('seq')
+    @pydantic.v1.validator('seq')
     def validate_seq(cls, v: object) -> object:
         if isinstance(v, int):
             data_models.validate_cesion_seq(v)
         return v
 
-    @pydantic.validator('monto_cesion')
+    @pydantic.v1.validator('monto_cesion')
     def validate_monto_cesion(cls, v: object) -> object:
         if isinstance(v, int):
             data_models.validate_cesion_monto(v)
         return v
 
-    @pydantic.validator(
+    @pydantic.v1.validator(
         'cedente_razon_social',
         'cesionario_razon_social',
     )
@@ -334,13 +334,13 @@ class CesionAecXml:
             dte_data_models.validate_contribuyente_razon_social(v)
         return v
 
-    @pydantic.validator('fecha_cesion_dt')
+    @pydantic.v1.validator('fecha_cesion_dt')
     def validate_datetime_tz(cls, v: object) -> object:
         if isinstance(v, datetime):
             tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
         return v
 
-    @pydantic.root_validator(skip_on_failure=True)
+    @pydantic.v1.root_validator(skip_on_failure=True)
     def validate_fecha_cesion_dt_is_consistent_with_dte(
         cls,
         values: Mapping[str, object],
@@ -353,7 +353,7 @@ class CesionAecXml:
 
         return values
 
-    @pydantic.root_validator(skip_on_failure=True)
+    @pydantic.v1.root_validator(skip_on_failure=True)
     def validate_monto_cesion_does_not_exceed_dte_monto_total(
         cls,
         values: Mapping[str, object],
@@ -369,7 +369,7 @@ class CesionAecXml:
 
         return values
 
-    @pydantic.root_validator(skip_on_failure=True)
+    @pydantic.v1.root_validator(skip_on_failure=True)
     def validate_fecha_ultimo_vencimiento_is_consistent_with_dte(
         cls,
         values: Mapping[str, object],
@@ -385,7 +385,7 @@ class CesionAecXml:
         return values
 
 
-@pydantic.dataclasses.dataclass(
+@pydantic.v1.dataclasses.dataclass(
     frozen=True,
     config=type(
         'Config',
@@ -693,26 +693,26 @@ class AecXml:
     # Validators
     ###########################################################################
 
-    @pydantic.validator('dte')
+    @pydantic.v1.validator('dte')
     def validate_dte_tipo_dte(cls, v: object) -> object:
         if isinstance(v, dte_data_models.DteDataL0):
             data_models.validate_cesion_dte_tipo_dte(v.tipo_dte)
         return v
 
-    @pydantic.validator('fecha_firma_dt')
+    @pydantic.v1.validator('fecha_firma_dt')
     def validate_datetime_tz(cls, v: object) -> object:
         if isinstance(v, datetime):
             tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
         return v
 
-    @pydantic.validator('cesiones')
+    @pydantic.v1.validator('cesiones')
     def validate_cesiones_min_items(cls, v: object) -> object:
         if isinstance(v, Sequence):
             if len(v) < 1:
                 raise ValueError("must contain at least one item")
         return v
 
-    @pydantic.validator('cesiones')
+    @pydantic.v1.validator('cesiones')
     def validate_cesiones_seq_order(cls, v: object) -> object:
         if isinstance(v, Sequence):
             for idx, cesion in enumerate(v, start=1):
@@ -739,7 +739,7 @@ class AecXml:
 
     #     return v
 
-    @pydantic.root_validator(skip_on_failure=True)
+    @pydantic.v1.root_validator(skip_on_failure=True)
     def validate_dte_matches_cesiones_dtes(
         cls,
         values: Mapping[str, object],
@@ -761,7 +761,7 @@ class AecXml:
 
         return values
 
-    @pydantic.root_validator(skip_on_failure=True)
+    @pydantic.v1.root_validator(skip_on_failure=True)
     def validate_last_cesion_matches_some_fields(
         cls,
         values: Mapping[str, object],
@@ -795,7 +795,7 @@ class AecXml:
 
         return values
 
-    @pydantic.root_validator
+    @pydantic.v1.root_validator
     def validate_signature_value_and_signature_x509_cert_der_may_only_be_none_together(
         cls,
         values: Mapping[str, object],

--- a/src/cl_sii/rtc/parse_aec.py
+++ b/src/cl_sii/rtc/parse_aec.py
@@ -21,7 +21,7 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import Mapping, Optional, Sequence
 
-import pydantic
+import pydantic.v1
 
 import cl_sii.dte.data_models
 import cl_sii.dte.parse
@@ -104,7 +104,7 @@ def _validate_rut(v: object) -> object:
     return v
 
 
-class _XmlSignature(pydantic.BaseModel):
+class _XmlSignature(pydantic.v1.BaseModel):
     """
     Parser for ``//Signature``.
     """
@@ -112,7 +112,7 @@ class _XmlSignature(pydantic.BaseModel):
     class Config:
         allow_mutation = False
         anystr_strip_whitespace = True
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
         min_anystr_length = 1
 
     ###########################################################################
@@ -158,7 +158,7 @@ class _XmlSignature(pydantic.BaseModel):
     # Validators
     ###########################################################################
 
-    @pydantic.validator(
+    @pydantic.v1.validator(
         'signature_value',
         'key_info_x509_data_x509_cert',
         pre=True,
@@ -178,7 +178,7 @@ class _XmlSignature(pydantic.BaseModel):
     #     return v
 
 
-class _Cesionario(pydantic.BaseModel):
+class _Cesionario(pydantic.v1.BaseModel):
     """
     Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cesionario``.
     """
@@ -187,7 +187,7 @@ class _Cesionario(pydantic.BaseModel):
         allow_mutation = False
         anystr_strip_whitespace = True
         arbitrary_types_allowed = True
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
         min_anystr_length = 1
 
     ###########################################################################
@@ -220,14 +220,14 @@ class _Cesionario(pydantic.BaseModel):
     # Validators
     ###########################################################################
 
-    _validate_rut = pydantic.validator(  # type: ignore[pydantic-field]
+    _validate_rut = pydantic.v1.validator(  # type: ignore[pydantic-field]
         'rut',
         pre=True,
         allow_reuse=True,
     )(_validate_rut)
 
 
-class _RutAutorizado(pydantic.BaseModel):
+class _RutAutorizado(pydantic.v1.BaseModel):
     """
     Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cedente/RUTAutorizado``.
     """
@@ -236,7 +236,7 @@ class _RutAutorizado(pydantic.BaseModel):
         allow_mutation = False
         anystr_strip_whitespace = True
         arbitrary_types_allowed = True
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
         min_anystr_length = 1
 
     ###########################################################################
@@ -265,20 +265,20 @@ class _RutAutorizado(pydantic.BaseModel):
     # Validators
     ###########################################################################
 
-    _empty_str_to_none = pydantic.validator(  # type: ignore[pydantic-field]
+    _empty_str_to_none = pydantic.v1.validator(  # type: ignore[pydantic-field]
         'nombre',
         pre=True,
         allow_reuse=True,
     )(_empty_str_to_none)
 
-    _validate_rut = pydantic.validator(  # type: ignore[pydantic-field]
+    _validate_rut = pydantic.v1.validator(  # type: ignore[pydantic-field]
         'rut',
         pre=True,
         allow_reuse=True,
     )(_validate_rut)
 
 
-class _Cedente(pydantic.BaseModel):
+class _Cedente(pydantic.v1.BaseModel):
     """
     Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cedente``.
     """
@@ -287,7 +287,7 @@ class _Cedente(pydantic.BaseModel):
         allow_mutation = False
         anystr_strip_whitespace = True
         arbitrary_types_allowed = True
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
         min_anystr_length = 1
 
     ###########################################################################
@@ -338,13 +338,13 @@ class _Cedente(pydantic.BaseModel):
     # Validators
     ###########################################################################
 
-    @pydantic.validator('rut', pre=True)
+    @pydantic.v1.validator('rut', pre=True)
     def validate_rut(cls, v: object) -> object:
         if isinstance(v, str):
             v = Rut(value=v, validate_dv=False)  # Raises ValueError if invalid.
         return v
 
-    @pydantic.validator('ruts_autorizados')
+    @pydantic.v1.validator('ruts_autorizados')
     def validate_ruts_autorizados_item_count(cls, v: object) -> object:
         if isinstance(v, Sequence):
             if len(v) < 1:
@@ -354,7 +354,7 @@ class _Cedente(pydantic.BaseModel):
         return v
 
 
-class _IdDte(pydantic.BaseModel):
+class _IdDte(pydantic.v1.BaseModel):
     """
     Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/IdDTE``.
     """
@@ -362,7 +362,7 @@ class _IdDte(pydantic.BaseModel):
     class Config:
         allow_mutation = False
         arbitrary_types_allowed = True
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
 
     ###########################################################################
     # Fields
@@ -408,26 +408,26 @@ class _IdDte(pydantic.BaseModel):
     # Validators
     ###########################################################################
 
-    _validate_rut_emisor = pydantic.validator(  # type: ignore[pydantic-field]
+    _validate_rut_emisor = pydantic.v1.validator(  # type: ignore[pydantic-field]
         'rut_emisor',
         pre=True,
         allow_reuse=True,
     )(_validate_rut)
 
-    _validate_rut_receptor = pydantic.validator(  # type: ignore[pydantic-field]
+    _validate_rut_receptor = pydantic.v1.validator(  # type: ignore[pydantic-field]
         'rut_receptor',
         pre=True,
         allow_reuse=True,
     )(_validate_rut)
 
-    @pydantic.validator('tipo_dte', pre=True)
+    @pydantic.v1.validator('tipo_dte', pre=True)
     def validate_tipo_dte(cls, v: object) -> object:
         if isinstance(v, int):
             v = TipoDte(v)  # Raises ValueError if invalid.
         return v
 
 
-class _DocumentoCesion(pydantic.BaseModel):
+class _DocumentoCesion(pydantic.v1.BaseModel):
     """
     Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion``.
     """
@@ -435,7 +435,7 @@ class _DocumentoCesion(pydantic.BaseModel):
     class Config:
         allow_mutation = False
         anystr_strip_whitespace = True
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
         min_anystr_length = 1
 
     ###########################################################################
@@ -498,7 +498,7 @@ class _DocumentoCesion(pydantic.BaseModel):
     # Validators
     ###########################################################################
 
-    @pydantic.validator('tmst_cesion')
+    @pydantic.v1.validator('tmst_cesion')
     def validate_datetime(cls, v: object) -> object:
         if isinstance(v, str):
             v = datetime.fromisoformat(v)
@@ -511,14 +511,14 @@ class _DocumentoCesion(pydantic.BaseModel):
         return v
 
 
-class _Cesion(pydantic.BaseModel):
+class _Cesion(pydantic.v1.BaseModel):
     """
     Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion``.
     """
 
     class Config:
         allow_mutation = False
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
 
     ###########################################################################
     # Fields
@@ -585,7 +585,7 @@ class _Cesion(pydantic.BaseModel):
         )
 
 
-class _DocumentoDteCedido(pydantic.BaseModel):
+class _DocumentoDteCedido(pydantic.v1.BaseModel):
     """
     Parser for ``/AEC/DocumentoAEC/Cesiones/DTECedido/DocumentoDTECedido``.
     """
@@ -593,7 +593,7 @@ class _DocumentoDteCedido(pydantic.BaseModel):
     class Config:
         allow_mutation = False
         arbitrary_types_allowed = True
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
 
     ###########################################################################
     # Fields
@@ -631,7 +631,7 @@ class _DocumentoDteCedido(pydantic.BaseModel):
     # Validators
     ###########################################################################
 
-    @pydantic.validator('dte', pre=True)
+    @pydantic.v1.validator('dte', pre=True)
     def validate_dte(cls, v: object) -> object:
         if isinstance(v, XmlElement):
             cl_sii.dte.parse.validate_dte_xml(v)
@@ -651,14 +651,14 @@ class _DocumentoDteCedido(pydantic.BaseModel):
     #     return v
 
 
-class _DteCedido(pydantic.BaseModel):
+class _DteCedido(pydantic.v1.BaseModel):
     """
     Parser for ``/AEC/DocumentoAEC/Cesiones/DTECedido``.
     """
 
     class Config:
         allow_mutation = False
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
 
     ###########################################################################
     # Fields
@@ -702,7 +702,7 @@ class _DteCedido(pydantic.BaseModel):
         )
 
 
-class _Caratula(pydantic.BaseModel):
+class _Caratula(pydantic.v1.BaseModel):
     """
     Parser for ``/AEC/DocumentoAEC/Caratula``.
     """
@@ -711,7 +711,7 @@ class _Caratula(pydantic.BaseModel):
         allow_mutation = False
         anystr_strip_whitespace = True
         arbitrary_types_allowed = True
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
         min_anystr_length = 1
 
     ###########################################################################
@@ -748,7 +748,7 @@ class _Caratula(pydantic.BaseModel):
     # Validators
     ###########################################################################
 
-    _empty_str_to_none = pydantic.validator(  # type: ignore[pydantic-field]
+    _empty_str_to_none = pydantic.v1.validator(  # type: ignore[pydantic-field]
         'nmb_contacto',
         'fono_contacto',
         'mail_contacto',
@@ -756,19 +756,19 @@ class _Caratula(pydantic.BaseModel):
         allow_reuse=True,
     )(_empty_str_to_none)
 
-    _validate_rut_cedente = pydantic.validator(  # type: ignore[pydantic-field]
+    _validate_rut_cedente = pydantic.v1.validator(  # type: ignore[pydantic-field]
         'rut_cedente',
         pre=True,
         allow_reuse=True,
     )(_validate_rut)
 
-    _validate_rut_cesionario = pydantic.validator(  # type: ignore[pydantic-field]
+    _validate_rut_cesionario = pydantic.v1.validator(  # type: ignore[pydantic-field]
         'rut_cesionario',
         pre=True,
         allow_reuse=True,
     )(_validate_rut)
 
-    @pydantic.validator('tmst_firmaenvio')
+    @pydantic.v1.validator('tmst_firmaenvio')
     def validate_datetime(cls, v: object) -> object:
         if isinstance(v, str):
             v = datetime.fromisoformat(v)
@@ -781,14 +781,14 @@ class _Caratula(pydantic.BaseModel):
         return v
 
 
-class _DocumentoAec(pydantic.BaseModel):
+class _DocumentoAec(pydantic.v1.BaseModel):
     """
     Parser for ``/AEC/DocumentoAEC``.
     """
 
     class Config:
         allow_mutation = False
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
 
     ###########################################################################
     # Fields
@@ -844,7 +844,7 @@ class _DocumentoAec(pydantic.BaseModel):
     # Validators
     ###########################################################################
 
-    @pydantic.validator('cesiones_cesion')
+    @pydantic.v1.validator('cesiones_cesion')
     def validate_cesiones_cesion_min_items(cls, v: object) -> object:
         if isinstance(v, Sequence):
             if len(v) < 1:
@@ -852,14 +852,14 @@ class _DocumentoAec(pydantic.BaseModel):
         return v
 
 
-class _Aec(pydantic.BaseModel):
+class _Aec(pydantic.v1.BaseModel):
     """
     Parser for ``/AEC``.
     """
 
     class Config:
         allow_mutation = False
-        extra = pydantic.Extra.forbid
+        extra = pydantic.v1.Extra.forbid
 
     ###########################################################################
     # Fields

--- a/src/tests/test_dte_data_models.py
+++ b/src/tests/test_dte_data_models.py
@@ -3,7 +3,7 @@ import dataclasses
 import unittest
 from datetime import date, datetime
 
-import pydantic
+import pydantic.v1
 
 from cl_sii.dte.constants import (
     DTE_FOLIO_FIELD_MAX_VALUE,
@@ -48,7 +48,7 @@ class DteNaturalKeyTest(unittest.TestCase):
         ]
 
         # Validate the minimum value of the field folio
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_nk_1,
                 folio=DTE_FOLIO_FIELD_MIN_VALUE - 1,
@@ -60,7 +60,7 @@ class DteNaturalKeyTest(unittest.TestCase):
             self.assertIn(expected_validation_error, validation_errors)
 
         # Validate the maximum value of the field folio
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_nk_1,
                 folio=DTE_FOLIO_FIELD_MAX_VALUE + 1,
@@ -136,7 +136,7 @@ class DteDataL1Test(unittest.TestCase):
                 tipo_dte=TipoDte.LIQUIDACION_FACTURA_ELECTRONICA,
                 monto_total=-1,
             )
-        except pydantic.ValidationError as exc:
+        except pydantic.v1.ValidationError as exc:
             self.fail(f'{exc.__class__.__name__} raised')
 
     def test_validate_monto_total_range(self) -> None:
@@ -149,7 +149,7 @@ class DteDataL1Test(unittest.TestCase):
         ]
 
         # Validate the minimum value of the field monto_total
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l1_1,
                 monto_total=DTE_MONTO_TOTAL_FIELD_MIN_VALUE - 1,
@@ -161,7 +161,7 @@ class DteDataL1Test(unittest.TestCase):
             self.assertIn(expected_validation_error, validation_errors)
 
         # Validate the maximum value of the field monto_total
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l1_1,
                 monto_total=DTE_MONTO_TOTAL_FIELD_MAX_VALUE + 1,
@@ -174,7 +174,7 @@ class DteDataL1Test(unittest.TestCase):
 
         # Validate the minimum value of the field monto_total
         # for a tipo_dte FACTURA_ELECTRONICA
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l1_1,
                 monto_total=-1,
@@ -331,7 +331,7 @@ class DteDataL2Test(unittest.TestCase):
                 emisor_razon_social=None,
                 receptor_razon_social=None,
             )
-        except pydantic.ValidationError as exc:
+        except pydantic.v1.ValidationError as exc:
             self.fail(f'{exc.__class__.__name__} raised')
 
     def test_validate_emisor_razon_social_empty(self) -> None:
@@ -343,7 +343,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 emisor_razon_social='',
@@ -363,7 +363,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 receptor_razon_social='',
@@ -385,7 +385,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 firma_documento_dt=datetime(2019, 4, 5, 12, 57, 32),
@@ -411,7 +411,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
@@ -455,7 +455,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 signature_value=b'',
@@ -496,7 +496,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 signature_x509_cert_der=b'',
@@ -516,7 +516,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 emisor_giro=' NASA ',
@@ -541,7 +541,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 emisor_email=' fake_emisor_email@test.cl ',
@@ -566,7 +566,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 receptor_email=' fake_receptor_email@test.cl ',
@@ -586,7 +586,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 emisor_giro='',
@@ -606,7 +606,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 emisor_email='',
@@ -626,7 +626,7 @@ class DteDataL2Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_l2_1,
                 receptor_email='',
@@ -746,7 +746,7 @@ class DteXmlReferenciaTest(unittest.TestCase):
 
         obj = self.obj_1
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 numero_linea_ref=0,
@@ -761,7 +761,7 @@ class DteXmlReferenciaTest(unittest.TestCase):
                 }
             ],
         )
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 numero_linea_ref=41,
@@ -782,7 +782,7 @@ class DteXmlReferenciaTest(unittest.TestCase):
 
         obj = self.obj_1
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 tipo_documento_ref="8001",
@@ -798,7 +798,7 @@ class DteXmlReferenciaTest(unittest.TestCase):
                 }
             ],
         )
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 tipo_documento_ref="2BAD",
@@ -820,7 +820,7 @@ class DteXmlReferenciaTest(unittest.TestCase):
 
         obj = self.obj_1
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 ind_global=2,
@@ -841,7 +841,7 @@ class DteXmlReferenciaTest(unittest.TestCase):
 
         obj = self.obj_2
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 folio_ref="",
@@ -862,7 +862,7 @@ class DteXmlReferenciaTest(unittest.TestCase):
 
         obj = self.obj_1
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 fecha_ref=date(2002, 7, 31),
@@ -878,7 +878,7 @@ class DteXmlReferenciaTest(unittest.TestCase):
                 }
             ],
         )
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 fecha_ref=date(2051, 1, 1),
@@ -900,7 +900,7 @@ class DteXmlReferenciaTest(unittest.TestCase):
 
         obj = self.obj_1
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 razon_ref=(
@@ -1065,7 +1065,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 emisor_razon_social='',
@@ -1085,7 +1085,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 receptor_razon_social='',
@@ -1105,7 +1105,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 emisor_razon_social=None,
@@ -1125,7 +1125,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 receptor_razon_social=None,
@@ -1147,7 +1147,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 firma_documento_dt=datetime(2019, 4, 5, 12, 57, 32),
@@ -1173,7 +1173,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
@@ -1217,7 +1217,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 signature_value=b'',
@@ -1258,7 +1258,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 signature_x509_cert_der=b'',
@@ -1278,7 +1278,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 emisor_giro=' NASA ',
@@ -1303,7 +1303,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 emisor_email=' fake_emisor_email@test.cl ',
@@ -1328,7 +1328,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 receptor_email=' fake_receptor_email@test.cl ',
@@ -1348,7 +1348,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 emisor_giro='',
@@ -1368,7 +1368,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 emisor_email='',
@@ -1388,7 +1388,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 receptor_email='',
@@ -1553,7 +1553,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 referencias=list(reversed(obj.referencias)),
@@ -1587,7 +1587,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 referencias=[obj_referencia],
@@ -1625,7 +1625,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 referencias=[obj_referencia],
@@ -1653,7 +1653,7 @@ class DteXmlDataTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 referencias=[obj_referencia],

--- a/src/tests/test_rcv_data_models.py
+++ b/src/tests/test_rcv_data_models.py
@@ -2,7 +2,7 @@ import dataclasses
 import unittest
 from datetime import date, datetime
 
-import pydantic
+import pydantic.v1
 
 import cl_sii.dte.constants
 from cl_sii.base.constants import SII_OFFICIAL_TZ
@@ -39,7 +39,7 @@ class PeriodoTributarioTest(unittest.TestCase):
         ]
 
         # Validate the minimum value of the field year
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.periodo_tributario_1,
                 year=1899,
@@ -60,7 +60,7 @@ class PeriodoTributarioTest(unittest.TestCase):
         ]
 
         # Validate the minimum value of the field month
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.periodo_tributario_1,
                 month=0,
@@ -72,7 +72,7 @@ class PeriodoTributarioTest(unittest.TestCase):
             self.assertIn(expected_validation_error, validation_errors)
 
         # Validate the maximum value of the field month
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.periodo_tributario_1,
                 month=13,
@@ -111,7 +111,7 @@ class RcvDetalleEntryTest(unittest.TestCase):
         ]
 
         # Validate the minimum value of the field folio
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rcv_detalle_entry_1,
                 folio=cl_sii.dte.constants.DTE_FOLIO_FIELD_MIN_VALUE - 1,
@@ -123,7 +123,7 @@ class RcvDetalleEntryTest(unittest.TestCase):
             self.assertIn(expected_validation_error, validation_errors)
 
         # Validate the maximum value of the field folio
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rcv_detalle_entry_1,
                 folio=cl_sii.dte.constants.DTE_FOLIO_FIELD_MAX_VALUE + 1,
@@ -145,7 +145,7 @@ class RcvDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rcv_detalle_entry_1,
                 fecha_recepcion_dt=datetime(2019, 4, 5, 12, 57, 32),
@@ -171,7 +171,7 @@ class RcvDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rcv_detalle_entry_1,
                 fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
@@ -227,7 +227,7 @@ class RvDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rv_detalle_entry_1,
                 receptor_razon_social='',
@@ -250,7 +250,7 @@ class RvDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rv_detalle_entry_1,
                 fecha_acuse_dt=datetime(2019, 4, 5, 12, 57, 32),
@@ -276,7 +276,7 @@ class RvDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rv_detalle_entry_1,
                 fecha_acuse_dt=tz_utils.convert_naive_dt_to_tz_aware(
@@ -301,7 +301,7 @@ class RvDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rv_detalle_entry_1,
                 fecha_reclamo_dt=datetime(2019, 4, 5, 12, 57, 32),
@@ -327,7 +327,7 @@ class RvDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rv_detalle_entry_1,
                 fecha_reclamo_dt=tz_utils.convert_naive_dt_to_tz_aware(
@@ -379,7 +379,7 @@ class RcRegistroDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rc_registro_detalle_entry_1,
                 emisor_razon_social='',
@@ -401,7 +401,7 @@ class RcRegistroDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rc_registro_detalle_entry_1,
                 fecha_acuse_dt=datetime(2019, 4, 5, 12, 57, 32),
@@ -427,7 +427,7 @@ class RcRegistroDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rc_registro_detalle_entry_1,
                 fecha_acuse_dt=tz_utils.convert_naive_dt_to_tz_aware(
@@ -502,7 +502,7 @@ class RcReclamadoDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rc_reclamado_detalle_entry_1,
                 emisor_razon_social='',
@@ -524,7 +524,7 @@ class RcReclamadoDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rc_reclamado_detalle_entry_1,
                 fecha_reclamo_dt=datetime(2019, 4, 5, 12, 57, 32),
@@ -550,7 +550,7 @@ class RcReclamadoDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rc_reclamado_detalle_entry_1,
                 fecha_reclamo_dt=tz_utils.convert_naive_dt_to_tz_aware(
@@ -592,7 +592,7 @@ class RcPendienteDetalleEntryTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.rc_pendiente_detalle_entry_1,
                 emisor_razon_social='',

--- a/src/tests/test_rtc_data_models.py
+++ b/src/tests/test_rtc_data_models.py
@@ -4,7 +4,7 @@ import dataclasses
 import unittest
 from datetime import date, datetime
 
-import pydantic
+import pydantic.v1
 
 from cl_sii.dte.constants import TipoDte
 from cl_sii.dte.data_models import DteDataL1, DteDataL2, DteNaturalKey
@@ -91,7 +91,7 @@ class CesionNaturalKeyTest(unittest.TestCase):
             'type': 'value_error',
         }
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 dte_key=dataclasses.replace(
@@ -116,7 +116,7 @@ class CesionNaturalKeyTest(unittest.TestCase):
                 'type': 'value_error',
             }
 
-            with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
                 dataclasses.replace(
                     obj,
                     seq=test_value,
@@ -211,7 +211,7 @@ class CesionAltNaturalKeyTest(unittest.TestCase):
             'type': 'value_error',
         }
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 dte_key=dataclasses.replace(
@@ -236,7 +236,7 @@ class CesionAltNaturalKeyTest(unittest.TestCase):
             'type': 'value_error',
         }
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 fecha_cesion_dt=datetime(2019, 4, 5, 12, 57),
@@ -258,7 +258,7 @@ class CesionAltNaturalKeyTest(unittest.TestCase):
             'type': 'value_error',
         }
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
@@ -432,7 +432,7 @@ class CesionL0Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 dte_key=dataclasses.replace(
@@ -461,7 +461,7 @@ class CesionL0Test(unittest.TestCase):
                 },
             ]
 
-            with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
                 dataclasses.replace(
                     obj,
                     seq=test_value,
@@ -487,7 +487,7 @@ class CesionL0Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 fecha_cesion_dt=datetime(2019, 4, 5, 12, 57, 32),
@@ -513,7 +513,7 @@ class CesionL0Test(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
@@ -663,7 +663,7 @@ class CesionL1Test(CesionL0Test):
                 },
             ]
 
-            with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
                 dataclasses.replace(
                     obj,
                     monto_cedido=test_value,
@@ -686,7 +686,7 @@ class CesionL1Test(CesionL0Test):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 monto_cedido=1000,
@@ -895,7 +895,7 @@ class CesionL2Test(CesionL1Test):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 fecha_cesion_dt=datetime(2019, 4, 5, 12, 57, 32),
@@ -932,7 +932,7 @@ class CesionL2Test(CesionL1Test):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
@@ -979,7 +979,7 @@ class CesionL2Test(CesionL1Test):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 cedente_razon_social='',

--- a/src/tests/test_rtc_data_models_aec.py
+++ b/src/tests/test_rtc_data_models_aec.py
@@ -4,7 +4,7 @@ import dataclasses
 import unittest
 from datetime import date, datetime
 
-import pydantic
+import pydantic.v1
 
 from cl_sii.dte.constants import TipoDte
 from cl_sii.dte.data_models import DteDataL1, DteNaturalKey, DteXmlData
@@ -464,7 +464,7 @@ class AecXmlTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 dte=dataclasses.replace(
@@ -493,7 +493,7 @@ class AecXmlTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 fecha_firma_dt=datetime(2019, 4, 5, 12, 57, 32),
@@ -519,7 +519,7 @@ class AecXmlTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 fecha_firma_dt=tz_utils.convert_naive_dt_to_tz_aware(
@@ -546,7 +546,7 @@ class AecXmlTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 cesiones=[],
@@ -570,7 +570,7 @@ class AecXmlTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 cesiones=list(reversed(obj.cesiones)),
@@ -639,7 +639,7 @@ class AecXmlTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 cesiones=[
@@ -677,7 +677,7 @@ class AecXmlTest(unittest.TestCase):
             },
         ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+        with self.assertRaises(pydantic.v1.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
                 cedente_rut=obj.cesionario_rut,


### PR DESCRIPTION
This update switches to `pydantic==2.3.0` but retains the code from the previous version.
Subsequent commits will introduce changes to utilize the features from version 2.

Ref: https://app.shortcut.com/cordada/story/768/update-lib-cl-sii-python
Ref: [sc-768]