### PR TITLE
dte: Improve validation error message in `DteXmlData.referencias`

### DIFF
--- a/src/cl_sii/dte/data_models.py
+++ b/src/cl_sii/dte/data_models.py
@@ -811,7 +811,13 @@ class DteXmlData(DteDataL1):
         if isinstance(v, Sequence):
             for idx, referencia in enumerate(v, start=1):
                 if referencia.numero_linea_ref != idx:
-                    raise ValueError("items must be ordered according to their 'numero_linea_ref'")
+                    raise ValueError(
+                        "items must be ordered according to their 'numero_linea_ref'. "
+                        f"Expected index value: {idx}, "
+                        f"actual numero linea ref: {referencia.numero_linea_ref}. "
+                        f"All numero_linea_refs: "
+                        f"{', '.join(str(ref.numero_linea_ref) for ref in v)}"
+                    )
         return v
 
     @pydantic.model_validator(mode='after')

--- a/src/tests/test_dte_data_models.py
+++ b/src/tests/test_dte_data_models.py
@@ -1699,7 +1699,11 @@ class DteXmlDataTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('referencias',),
-                'msg': "Value error, items must be ordered according to their 'numero_linea_ref'",
+                'msg': (
+                    "Value error, items must be ordered according to their 'numero_linea_ref'. "
+                    "Expected index value: 1, actual numero linea ref: 2. "
+                    "All numero_linea_refs: 2, 1"
+                ),
                 'type': 'value_error',
             },
         ]


### PR DESCRIPTION
* Improved exception message at `.DteXmlData.validate_referencias_numero_linea_ref_order`
* Included Expected an actual value
* Added list of all actual values or `DteXmlData.referencias` in message

Ref: https://app.shortcut.com/cordada/story/1493/