### PR TITLE
Remove Make task `python-wheel-install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ PYTHON = python3
 PYTHON_PIP = $(PYTHON) -m pip
 PYTHON_PIP_VERSION_SPECIFIER = ==22.3.1
 PYTHON_SETUPTOOLS_VERSION_SPECIFIER = ==58.1.0
-PYTHON_WHEEL_VERSION_SPECIFIER = ==0.38.4
 PYTHON_VIRTUALENV_DIR = venv
 PYTHON_PIP_TOOLS_VERSION_SPECIFIER = ==6.14.0
 PYTHON_PIP_TOOLS_SRC_FILES = requirements.in requirements-dev.in
@@ -28,7 +27,7 @@ TOXENV ?= py310
 .PHONY: build dist deploy upload-release
 .PHONE: python-virtualenv
 .PHONY: python-deps-compile python-deps-sync-check python-pip-tools-install
-.PHONY: python-pip-install python-setuptools-install python-wheel-install
+.PHONY: python-pip-install python-setuptools-install
 
 help:
 	@grep '^[a-zA-Z]' $(MAKEFILE_LIST) | sort | awk -F ':.*?## ' 'NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
@@ -61,7 +60,7 @@ install-dev: ## Install for development
 	python -m pip install --editable .
 	python -m pip check
 
-install-deps-dev: python-pip-install python-setuptools-install python-wheel-install
+install-deps-dev: python-pip-install python-setuptools-install
 install-deps-dev: python-pip-tools-install
 install-deps-dev: ## Install dependencies for development
 	python -m pip install -r requirements.txt
@@ -131,9 +130,6 @@ python-pip-install: ## Install Pip
 
 python-setuptools-install: ## Install Setuptools
 	$(PYTHON_PIP) install 'setuptools$(PYTHON_SETUPTOOLS_VERSION_SPECIFIER)'
-
-python-wheel-install: ## Install Wheel
-	$(PYTHON_PIP) install 'wheel$(PYTHON_WHEEL_VERSION_SPECIFIER)'
 
 python-deps-compile: $(patsubst %,python-deps-compile-%,$(PYTHON_PIP_TOOLS_SRC_FILES))
 python-deps-compile: ## Compile Python dependency manifests


### PR DESCRIPTION
This task is no longer needed since we are installing `wheel` through dependency manifest files `requirements-dev.in` and `requirements-dev.txt`.