### PR TITLE
dte: Allow gaps when validating order of `DteXmlData.referencias`

### DIFF
--- a/src/cl_sii/dte/data_models.py
+++ b/src/cl_sii/dte/data_models.py
@@ -809,15 +809,13 @@ class DteXmlData(DteDataL1):
     @classmethod
     def validate_referencias_numero_linea_ref_order(cls, v: object) -> object:
         if isinstance(v, Sequence):
-            for idx, referencia in enumerate(v, start=1):
-                if referencia.numero_linea_ref != idx:
-                    raise ValueError(
-                        "items must be ordered according to their 'numero_linea_ref'. "
-                        f"Expected index value: {idx}, "
-                        f"actual numero linea ref: {referencia.numero_linea_ref}. "
-                        f"All numero_linea_refs: "
-                        f"{', '.join(str(ref.numero_linea_ref) for ref in v)}"
-                    )
+            numero_linea_refs = [referencia.numero_linea_ref for referencia in v]
+            if numero_linea_refs != sorted(numero_linea_refs):
+                raise ValueError(
+                    "items must be ordered according to their 'numero_linea_ref'. "
+                    f"All numero_linea_refs: "
+                    f"{', '.join(str(num_linea_ref) for num_linea_ref in numero_linea_refs)}"
+                )
         return v
 
     @pydantic.model_validator(mode='after')

--- a/src/tests/test_dte_data_models.py
+++ b/src/tests/test_dte_data_models.py
@@ -1701,7 +1701,6 @@ class DteXmlDataTest(unittest.TestCase):
                 'loc': ('referencias',),
                 'msg': (
                     "Value error, items must be ordered according to their 'numero_linea_ref'. "
-                    "Expected index value: 1, actual numero linea ref: 2. "
                     "All numero_linea_refs: 2, 1"
                 ),
                 'type': 'value_error',


### PR DESCRIPTION
Relax validation of ordering of `DteXmlData.referencias` by `numero_linea_ref` by allowing ordered sequences of `referencias` to have gaps.

Ref: https://app.shortcut.com/cordada/story/3733 [sc-3733]
Related: https://github.com/cordada/lib-cl-sii-python/pull/557