### PR TITLE
fix: Add default value for missing code `098` in SII CTE Form 29

### DIFF
--- a/src/cl_sii/cte/f29/parse_datos_obj.py
+++ b/src/cl_sii/cte/f29/parse_datos_obj.py
@@ -182,7 +182,7 @@ def cte_f29_datos_schema_default_validator(
     if datos_obj['campos'].keys() != datos_obj['tipos'].keys():
         raise JsonSchemaValidationError("The keys of 'campos' and 'tipos' are not exactly the same")
     if datos_obj['campos'].keys() != datos_obj['glosa'].keys():
-        raise JsonSchemaValidationError("The keys of 'campos' and 'tipos' are not exactly the same")
+        raise JsonSchemaValidationError("The keys of 'campos' and 'glosa' are not exactly the same")
 
     return datos_obj
 

--- a/src/cl_sii/data/cte/f29_datos_obj_missing_key_fixes.json
+++ b/src/cl_sii/data/cte/f29_datos_obj_missing_key_fixes.json
@@ -1,12 +1,14 @@
 {
   "glosa": {
     "049": "(Desconocido)",
+    "098": "(Desconocido)",
     "156": "BASE IMPTO.A74,T.V.",
     "157": "RET..ART74,T.VAR",
     "8020": "(Desconocido)"
   },
   "tipos": {
     "049": "M",
+    "098":  "M",
     "156": "M",
     "157": "M",
     "8020": "M"


### PR DESCRIPTION
- Add code `098` to file used by schema validator
:func:`cte_f29_datos_schema_best_effort_validator`, since this code is currently missing in the `tipos` and `glosa` sections of the F29 file.

- Fixed exception message when the keys of `campos` and `glosa` are different

Ref: https://app.shortcut.com/cordada/story/3852/
Ref: [FD-CL-DATA-230](https://fynpal-com.sentry.io/issues/4907498672/)
Fixes: FD-CL-DATA-230 