### PR TITLE
chore(deps): Update package `zipp` from 3.8.1 to 3.19.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --strip-extras requirements-dev.in
 #
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -c requirements.txt
     #   referencing
@@ -18,11 +18,11 @@ bumpversion==0.5.3
     # via -r requirements-dev.in
 cachetools==5.3.1
     # via tox
-certifi==2023.7.22
+certifi==2024.7.4
     # via
     #   -c requirements.txt
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   -c requirements.txt
     #   cryptography
@@ -80,7 +80,7 @@ mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-packaging==23.1
+packaging==24.1
     # via
     #   -c requirements.txt
     #   black
@@ -102,7 +102,7 @@ pluggy==1.3.0
     # via tox
 pycodestyle==2.11.0
     # via flake8
-pycparser==2.20
+pycparser==2.22
     # via
     #   -c requirements.txt
     #   cffi
@@ -120,7 +120,7 @@ pyproject-hooks==1.0.0
     #   pip-tools
 readme-renderer==35.0
     # via twine
-referencing==0.30.2
+referencing==0.35.1
     # via
     #   -c requirements.txt
     #   types-jsonschema
@@ -134,7 +134,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.5.2
     # via twine
-rpds-py==0.10.6
+rpds-py==0.19.0
     # via
     #   -c requirements.txt
     #   referencing
@@ -165,7 +165,7 @@ types-pytz==2024.1.0.20240417
     # via -r requirements-dev.in
 types-setuptools==69.5.0.20240415
     # via types-cffi
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via
     #   -c requirements.txt
     #   black
@@ -183,7 +183,7 @@ wheel==0.43.0
     # via
     #   -r requirements-dev.in
     #   pip-tools
-zipp==3.8.1
+zipp==3.19.2
     # via
     #   -c requirements.txt
     #   importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --allow-unsafe --strip-extras requirements.in
 #
-annotated-types==0.5.0
+annotated-types==0.7.0
     # via pydantic
 asgiref==3.8.1
     # via django
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
@@ -17,9 +17,9 @@ backports-zoneinfo==0.2.1 ; python_version < "3.9"
     #   -r requirements.in
     #   django
     #   djangorestframework
-certifi==2023.7.22
+certifi==2024.7.4
     # via signxml
-cffi==1.15.1
+cffi==1.16.0
     # via cryptography
 cryptography==42.0.8
     # via
@@ -36,13 +36,13 @@ djangorestframework==3.15.2
     # via -r requirements.in
 importlib-metadata==7.1.0
     # via -r requirements.in
-importlib-resources==6.1.0
+importlib-resources==6.4.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 jsonschema==4.22.0
     # via -r requirements.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 lxml==5.2.1
     # via
@@ -50,11 +50,11 @@ lxml==5.2.1
     #   signxml
 marshmallow==3.21.1
     # via -r requirements.in
-packaging==23.1
+packaging==24.1
     # via marshmallow
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pycparser==2.20
+pycparser==2.22
     # via cffi
 pydantic==2.7.2
     # via -r requirements.in
@@ -66,11 +66,11 @@ pyopenssl==24.1.0
     #   signxml
 pytz==2024.1
     # via -r requirements.in
-referencing==0.30.2
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.10.6
+rpds-py==0.19.0
     # via
     #   jsonschema
     #   referencing
@@ -78,13 +78,13 @@ signxml==3.2.2
     # via -r requirements.in
 sqlparse==0.5.0
     # via django
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via
     #   annotated-types
     #   asgiref
     #   pydantic
     #   pydantic-core
-zipp==3.8.1
+zipp==3.19.2
     # via
     #   importlib-metadata
     #   importlib-resources


### PR DESCRIPTION
Update package `zipp` to version 3.19.2 in compiled dependency files

- [Package Manager](https://pypi.org/project/zipp/)
- [Software Repository](https://github.com/jaraco/zipp)
- [Commits](https://github.com/jaraco/zipp/compare/v3.8.1...v3.19.2)

Fixes: https://github.com/cordada/lib-cl-sii-python/security/dependabot/54
Fixes: https://github.com/cordada/lib-cl-sii-python/security/dependabot/55