### PR TITLE
extras: Add mapping of Django model fields to DRF serializer fields

### DIFF
--- a/src/cl_sii/extras/drf_serializers.py
+++ b/src/cl_sii/extras/drf_serializers.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+
+try:
+    import rest_framework
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("Package 'djangorestframework' is required to use this module.") from exc
+try:
+    import django
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("Package 'Django' is required to use this module.") from exc
+
+from typing import Mapping, Type
+
+import django.db.models
+import rest_framework.serializers
+
+import cl_sii.extras.dj_model_fields
+import cl_sii.extras.drf_fields
+
+
+model_serializer_field_mapping: Mapping[
+    Type[django.db.models.Field], Type[rest_framework.serializers.Field]
+]
+"""
+Mapping of Django model fields to DRF serializer fields.
+
+Use this to extend DRF serializers that inherit from :class:`ModelSerializer` so
+that Django model fields from :mod:`cl_sii.extras.dj_model_fields` do not have
+to be explicitly defined in the serializer.
+
+Usage example:
+
+>>> class ExampleSerializer(rest_framework.serializers.ModelSerializer):
+...     serializer_field_mapping = {
+...         **rest_framework.serializers.ModelSerializer.serializer_field_mapping,
+...         **model_serializer_field_mapping,
+...     }
+"""
+model_serializer_field_mapping = {
+    cl_sii.extras.dj_model_fields.RutField: cl_sii.extras.drf_fields.RutField,
+}

--- a/src/tests/test_extras_drf_serializers.py
+++ b/src/tests/test_extras_drf_serializers.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import unittest
+
+import django.db.models
+import rest_framework.serializers
+
+import cl_sii.extras.drf_serializers
+
+
+class ModelSerializerFieldMappingTestCase(unittest.TestCase):
+    """
+    Tests for :attr:`model_serializer_field_mapping`.
+    """
+
+    def test_types(self) -> None:
+        serializer_field_mapping = {
+            **rest_framework.serializers.ModelSerializer.serializer_field_mapping,
+            **cl_sii.extras.drf_serializers.model_serializer_field_mapping,
+        }
+
+        for k, v in serializer_field_mapping.items():
+            self.assertTrue(issubclass(k, django.db.models.Field))
+            self.assertTrue(issubclass(v, rest_framework.serializers.Field))


### PR DESCRIPTION
Use it to extend DRF serializers that inherit from `ModelSerializer` so that Django model fields from `cl_sii.extras.dj_model_fields` do not have to be explicitly defined in the serializer.

The source code originates from an internal application (see commit 3bea7182 of that application’s source code), and was originally written by Jose Tomas Robles Hahn.