### PR TITLE
Test coverage broken by migration from `setup.py` to `pyproject.toml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test-all: ## run tests on every Python version with tox
 	tox
 
 test-coverage: ## run tests and record test coverage
-	coverage run --rcfile=setup.cfg setup.py test
+	coverage run --rcfile=setup.cfg -m unittest discover -v -c -b -s src -t src
 
 test-coverage-report: test-coverage-report-console
 test-coverage-report: test-coverage-report-xml

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/cl_sii
-commands = coverage run --rcfile=setup.cfg setup.py test
+commands = coverage run --rcfile=setup.cfg -m unittest discover -v -c -b -s src -t src
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
`setup.py test` has been deprecated for years. See:

- https://github.com/pypa/setuptools/issues/1684
- https://github.com/pypa/setuptools/pull/4522

Ref: https://github.com/cordada/lib-cl-sii-python/pull/675