### PR TITLE
Replace `setup.py sdist` and `bdist_wheel` with `build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,8 @@ build: ## Build Python package
 	$(PYTHON) setup.py build
 
 dist: build ## builds source and wheel package
-	python setup.py sdist
-	python setup.py bdist_wheel
+	python -m build --sdist
+	python -m build --wheel
 	twine check dist/*
 	ls -l dist
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,6 @@ cl_sii = [
 
 [tool.setuptools.dynamic]
 version = {attr = "cl_sii.__version__"}
+
+[tool.distutils.bdist_wheel]
+universal = false

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,6 +5,7 @@
 -c requirements.txt
 
 black==24.8.0
+build==1.0.3
 bumpversion==0.5.3
 coverage==7.6.1
 flake8==7.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,9 @@ black==24.8.0
 bleach==5.0.1
     # via readme-renderer
 build==1.0.3
-    # via pip-tools
+    # via
+    #   -r requirements-dev.in
+    #   pip-tools
 bumpversion==0.5.3
     # via -r requirements-dev.in
 cachetools==5.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 0


### PR DESCRIPTION
Setuptools has deprecated `python setup.py sdist` and `python setup.py bdist_wheel` in favor of `python -m build`.

This commit replaces the deprecated commands with the new `python -m build` command in `Makefile`, and moves the tool's configuration from `setup.cfg` to `pyproject.toml`.

See also: [How to modernize a `setup.py`` based project?](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/) ([GitHub](https://github.com/pypa/packaging.python.org/blob/afb69f3d/source/guides/modernize-setup-py-project.rst))