### PR TITLE
cte: Close file object in `f29.parse_datos_obj`

### DIFF
--- a/src/cl_sii/cte/f29/parse_datos_obj.py
+++ b/src/cl_sii/cte/f29/parse_datos_obj.py
@@ -28,9 +28,8 @@ CTE_F29_DATOS_OBJ_SCHEMA = read_json_schema(_CTE_F29_DATOS_OBJ_SCHEMA_PATH)
 _CTE_F29_DATOS_OBJ_MISSING_KEY_FIXES_PATH = (
     Path(__file__).parent.parent.parent / 'data' / 'cte' / 'f29_datos_obj_missing_key_fixes.json'
 )
-CTE_F29_DATOS_OBJ_MISSING_KEY_FIXES: SiiCteF29DatosObjType = json.load(
-    open(_CTE_F29_DATOS_OBJ_MISSING_KEY_FIXES_PATH)
-)
+with open(_CTE_F29_DATOS_OBJ_MISSING_KEY_FIXES_PATH) as f:
+    CTE_F29_DATOS_OBJ_MISSING_KEY_FIXES: SiiCteF29DatosObjType = json.load(f)
 
 
 def parse_sii_cte_f29_datos_obj(


### PR DESCRIPTION
Fix the following warning:

> cl_sii/cte/f29/parse_datos_obj.py:31:
> ResourceWarning: unclosed file
> <_io.TextIOWrapper name='cl_sii/data/cte/f29_datos_obj_missing_key_fixes.json' mode='r' encoding='UTF-8'>
> CTE_F29_DATOS_OBJ_MISSING_KEY_FIXES: SiiCteF29DatosObjType = json.load(