### PR TITLE
Improvements and fixes related to validation of trusted inputs

### DIFF
--- a/src/cl_sii/dte/data_models.py
+++ b/src/cl_sii/dte/data_models.py
@@ -918,3 +918,6 @@ class DteXmlData(DteDataL1):
                     )
 
         return self
+
+
+DTE_XML_DATA_PYDANTIC_TYPE_ADAPTER = pydantic.TypeAdapter(DteXmlData)

--- a/src/cl_sii/dte/parse.py
+++ b/src/cl_sii/dte/parse.py
@@ -117,7 +117,7 @@ def validate_dte_xml(xml_doc: XmlElement) -> None:
     xml_utils.validate_xml_doc(DTE_XML_SCHEMA_OBJ, xml_doc)
 
 
-def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
+def parse_dte_xml(xml_doc: XmlElement, trust_input: bool = False) -> data_models.DteXmlData:
     """
     Parse data from a DTE XML doc.
 
@@ -125,6 +125,16 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
         It is assumed that ``xml_doc`` is an
         ``{http://www.sii.cl/SiiDte}/DTE``  XML element.
 
+    :param xml_doc:
+        DTE XML document.
+    :param trust_input:
+        If ``True``, the input data is trusted to be valid and
+        some validation errors are replaced by warnings.
+
+        .. warning::
+            Use this option *only* if the DTE XML document was obtained directly
+            from the SII *and* you need to work around some validation errors
+            that the SII should have caught, but let through.
     :raises ValueError:
     :raises TypeError:
     :raises NotImplementedError:
@@ -511,23 +521,28 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
         _text_strip_or_raise(signature_key_info_x509_cert_em)
     )
 
-    return data_models.DteXmlData(
-        emisor_rut=emisor_rut_value,
-        tipo_dte=tipo_dte_value,
-        folio=folio_value,
-        fecha_emision_date=fecha_emision_value,
-        receptor_rut=receptor_rut_value,
-        monto_total=monto_total_value,
-        emisor_razon_social=emisor_razon_social_value,
-        receptor_razon_social=receptor_razon_social_value,
-        fecha_vencimiento_date=fecha_vencimiento_value,
-        firma_documento_dt=tmst_firma_value,
-        signature_value=signature_signature_value,
-        signature_x509_cert_der=signature_key_info_x509_cert_der,
-        emisor_giro=emisor_giro_value,
-        emisor_email=emisor_email_value,
-        receptor_email=receptor_email_value,
-        referencias=referencia_xml_list,
+    return data_models.DTE_XML_DATA_PYDANTIC_TYPE_ADAPTER.validate_python(
+        dict(
+            emisor_rut=emisor_rut_value,
+            tipo_dte=tipo_dte_value,
+            folio=folio_value,
+            fecha_emision_date=fecha_emision_value,
+            receptor_rut=receptor_rut_value,
+            monto_total=monto_total_value,
+            emisor_razon_social=emisor_razon_social_value,
+            receptor_razon_social=receptor_razon_social_value,
+            fecha_vencimiento_date=fecha_vencimiento_value,
+            firma_documento_dt=tmst_firma_value,
+            signature_value=signature_signature_value,
+            signature_x509_cert_der=signature_key_info_x509_cert_der,
+            emisor_giro=emisor_giro_value,
+            emisor_email=emisor_email_value,
+            receptor_email=receptor_email_value,
+            referencias=referencia_xml_list,
+        ),
+        context={
+            data_models.VALIDATION_CONTEXT_TRUST_INPUT: trust_input,
+        },
     )
 
 

--- a/src/cl_sii/rtc/data_models_aec.py
+++ b/src/cl_sii/rtc/data_models_aec.py
@@ -798,3 +798,6 @@ class AecXml:
             )
 
         return self
+
+
+AEC_XML_PYDANTIC_TYPE_ADAPTER = pydantic.TypeAdapter(AecXml)

--- a/src/tests/test_dte_data_models.py
+++ b/src/tests/test_dte_data_models.py
@@ -14,6 +14,7 @@ from cl_sii.dte.constants import (
     TipoDte,
 )
 from cl_sii.dte.data_models import (  # noqa: F401
+    DTE_XML_DATA_PYDANTIC_TYPE_ADAPTER,
     VALIDATION_CONTEXT_TRUST_INPUT,
     DteDataL0,
     DteDataL1,
@@ -1062,8 +1063,6 @@ class DteXmlDataTest(unittest.TestCase):
             'test_data/sii-crypto/DTE--96670340-7--61--110616-cert.der'
         )
 
-        cls.dte_xml_data_pydantic_type_adapter = pydantic.TypeAdapter(DteXmlData)
-
     def setUp(self) -> None:
         super().setUp()
 
@@ -1788,7 +1787,7 @@ class DteXmlDataTest(unittest.TestCase):
         )
 
         invalid_but_trusted_obj: Mapping[str, object] = {
-            **self.dte_xml_data_pydantic_type_adapter.dump_python(obj),
+            **DTE_XML_DATA_PYDANTIC_TYPE_ADAPTER.dump_python(obj),
             **dict(
                 referencias=[obj_referencia],
             ),
@@ -1797,7 +1796,7 @@ class DteXmlDataTest(unittest.TestCase):
 
         try:
             with self.assertLogs('cl_sii.dte.data_models', level='WARNING') as assert_logs_cm:
-                self.dte_xml_data_pydantic_type_adapter.validate_python(
+                DTE_XML_DATA_PYDANTIC_TYPE_ADAPTER.validate_python(
                     invalid_but_trusted_obj, context=validation_context
                 )
         except pydantic.ValidationError as exc:
@@ -1876,7 +1875,7 @@ class DteXmlDataTest(unittest.TestCase):
         )
 
         invalid_but_trusted_obj: Mapping[str, object] = {
-            **self.dte_xml_data_pydantic_type_adapter.dump_python(obj),
+            **DTE_XML_DATA_PYDANTIC_TYPE_ADAPTER.dump_python(obj),
             **dict(
                 referencias=[obj_referencia],
             ),
@@ -1885,7 +1884,7 @@ class DteXmlDataTest(unittest.TestCase):
 
         try:
             with self.assertLogs('cl_sii.dte.data_models', level='WARNING') as assert_logs_cm:
-                self.dte_xml_data_pydantic_type_adapter.validate_python(
+                DTE_XML_DATA_PYDANTIC_TYPE_ADAPTER.validate_python(
                     invalid_but_trusted_obj, context=validation_context
                 )
         except pydantic.ValidationError as exc:


### PR DESCRIPTION
- dte: Add option to trust the input when parsing DTE XML documents.
- rtc: Fully propagate value of `trust_input` in `parse_aec_xml()`.

Ref: https://github.com/cordada/lib-cl-sii-python/pull/703
Ref: https://app.shortcut.com/cordada/story/9837