### PR TITLE
rut: Improve type annotation; Add method to validate DV

### DIFF
--- a/src/cl_sii/rut/__init__.py
+++ b/src/cl_sii/rut/__init__.py
@@ -140,6 +140,22 @@ class Rut:
         return hash(self.canonical)
 
     ############################################################################
+    # custom methods
+    ############################################################################
+
+    def validate_dv(self, raise_exception: bool = False) -> bool:
+        """
+        Whether the "digito verificador" of the RUT is correct.
+
+        :param raise_exception: Whether to raise an exception if validation fails.
+        :raises ValueError:
+        """
+        is_valid = self.calc_dv(self._digits) == self._dv
+        if not is_valid and raise_exception:
+            raise ValueError("RUT's \"digito verificador\" is incorrect.", self.canonical)
+        return is_valid
+
+    ############################################################################
     # class methods
     ############################################################################
 

--- a/src/cl_sii/rut/__init__.py
+++ b/src/cl_sii/rut/__init__.py
@@ -81,8 +81,7 @@ class Rut:
         self._dv = match_groups['dv']
 
         if validate_dv:
-            if Rut.calc_dv(self._digits) != self._dv:
-                raise ValueError("RUT's \"digito verificador\" is incorrect.", value)
+            self.validate_dv(raise_exception=True)
 
     ############################################################################
     # properties

--- a/src/cl_sii/rut/__init__.py
+++ b/src/cl_sii/rut/__init__.py
@@ -10,6 +10,8 @@ RUT "canonical format": no dots ('.'), with dash ('-'), uppercase K e.g.
 
 """
 
+from __future__ import annotations
+
 import itertools
 import random
 import re
@@ -50,7 +52,7 @@ class Rut:
 
     """
 
-    def __init__(self, value: str, validate_dv: bool = False) -> None:
+    def __init__(self, value: str | Rut, validate_dv: bool = False) -> None:
         """
         Constructor.
 

--- a/src/tests/test_rut.py
+++ b/src/tests/test_rut.py
@@ -262,6 +262,25 @@ class RutTest(unittest.TestCase):
         self.assertEqual(self.valid_rut_instance.__hash__(), rut_hash)
 
     ############################################################################
+    # custom methods
+    ############################################################################
+
+    def test_validate_dv(self) -> None:
+        self.assertIs(self.valid_rut_instance.validate_dv(), True)
+        self.assertIs(self.invalid_rut_instance.validate_dv(), False)
+
+    def test_validate_dv_raises_exception(self) -> None:
+        try:
+            self.valid_rut_instance.validate_dv(raise_exception=True)
+        except ValueError as exc:
+            self.fail(f'{exc.__class__.__name__} raised')
+
+        with self.assertRaisesRegex(
+            ValueError, r'''('RUT\\'s "digito verificador" is incorrect.', '6824160-0')'''
+        ):
+            self.invalid_rut_instance.validate_dv(raise_exception=True)
+
+    ############################################################################
     # class methods
     ############################################################################
 


### PR DESCRIPTION
- Improve type annotation of `Rut(value)`. `Rut.__init__()` is able to accept values of type `Rut` by converting them to `str`, so a more appropriate type annotation for `value` is `str | Rut` instead of just `str`.
- Add method `validate_dv()` to `Rut`. This method is useful when we want to validate the DV of a `Rut` that was instantiated with `validate_dv=False`.
- Refactor validation of DV in `Rut.__init__()`.