### PR TITLE
Release v0.38.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.37.0
+current_version = 0.38.0
 commit = True
 tag = False
 message = chore: Bump version from {current_version} to {new_version}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 0.38.0 (2024-10-28)
+
+- (PR #725, 2024-10-28) extras: Fix generation of JSON Schema for Pydantic `Rut` type
+- (PR #726, 2024-10-28) chore(deps): Update `mypy` from 1.11.2 to 1.13.0
+
 ## 0.37.0 (2024-10-25)
 
 - (PR #721, 2024-10-11) rut: Improve type annotation; Add method to validate DV

--- a/src/cl_sii/__init__.py
+++ b/src/cl_sii/__init__.py
@@ -4,4 +4,4 @@ cl-sii Python lib
 
 """
 
-__version__ = '0.37.0'
+__version__ = '0.38.0'


### PR DESCRIPTION
- (PR #725, 2024-10-28) extras: Fix generation of JSON Schema for Pydantic `Rut` type
- (PR #726, 2024-10-28) chore(deps): Update `mypy` from 1.11.2 to 1.13.0