### PR TITLE
deps: Update  cryptography to 44.0.0 and pyopenssl to 24.3.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,7 +40,7 @@ colorama==0.4.6
     # via tox
 coverage==7.6.1
     # via -r requirements-dev.in
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c requirements.txt
     #   secretstorage

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@
 #   git+https://github.com/example/example.git@example-vcs-ref#egg=example-pkg[foo,bar]==1.42.3
 
 backports-zoneinfo==0.2.1 ; python_version < "3.9" # Used by `djangorestframework`.
-cryptography==43.0.3
+cryptography==44.0.0
 defusedxml==0.7.1
 django-filter>=24.2
 Django>=2.2.24

--- a/requirements.in
+++ b/requirements.in
@@ -16,6 +16,6 @@ jsonschema==4.23.0
 lxml==5.3.0
 marshmallow==3.22.0
 pydantic==2.10.3
-pyOpenSSL==24.2.1
+pyOpenSSL==24.3.0
 pytz==2024.2
 signxml==4.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ certifi==2024.7.4
     # via signxml
 cffi==1.16.0
     # via cryptography
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -r requirements.in
     #   pyopenssl

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ pydantic==2.10.3
     # via -r requirements.in
 pydantic-core==2.27.1
     # via pydantic
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via -r requirements.in
 pytz==2024.2
     # via -r requirements.in


### PR DESCRIPTION
**chore(deps): Update cryptography from 43.0.3 to 44.0.0**

Bumps [cryptography](https://github.com/pyca/cryptography) from 43.0.3 to 44.0.0.
- [Changelog](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pyca/cryptography/compare/43.0.3...44.0.0)

**chore: Bump pyopenssl from 24.2.1 to 24.3.0**

Bumps [pyopenssl](https://github.com/pyca/pyopenssl) from 24.2.1 to 24.3.0.
- [Changelog](https://github.com/pyca/pyopenssl/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pyca/pyopenssl/compare/24.2.1...24.3.0)


Ref: https://app.shortcut.com/cordada/story/11838/ [sc-11838]
depends-on: https://github.com/cordada/lib-cl-sii-python/pull/736