### PR TITLE
deps: Update dependency constraints of Python package `cl-sii`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,13 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "cl-sii"
 dependencies = [
-  "cryptography>=38.0.0",
+  "cryptography>=43.0.0",
   "defusedxml>=0.6.0,<1",
   "jsonschema>=3.1.1",
-  "lxml>=4.6.5,<6",
+  "lxml>=5.2.1,<6",
   "marshmallow>=3,<4",
   "pydantic>=2.3.0,!=1.7.*,!=1.8.*,!=1.9.*",
-  "pyOpenSSL>=22.0.0",
+  "pyOpenSSL>=24.0.0",
   "pytz>=2019.3",
   "signxml>=4.0.0",
 ]


### PR DESCRIPTION
Increase minimum version of

- `cryptography`
- `lxml`
- `pyOpenSSL`

to prevent compatibility issues.