### PR TITLE
Exclude only individual test files in Mypy configuration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,7 +6,32 @@ mypy_path =
 files =
     *.py,
     src
-exclude = (^(src/tests)/.*$)
+exclude = (?x)(
+    ^src/tests/( # Tests
+        test_cte_f29_data_models
+        | test_dte_data_models
+        | test_dte_parse
+        | test_extras_dj_filters
+        | test_extras_dj_form_fields
+        | test_extras_dj_model_fields
+        | test_extras_mm_fields
+        | test_libs_crypto_utils
+        | test_libs_dataclass_utils
+        | test_libs_io_utils
+        | test_libs_tz_utils
+        | test_libs_xml_utils
+        | test_rcv_parse_csv
+        | test_rtc_data_models
+        | test_rtc_data_models_aec
+        | test_rtc_data_models_cesiones_periodo
+        | test_rtc_xml_utils
+        | test_rut
+        | test_rut_crypto_utils
+    )\.py$
+    | ^src/tests/( # Test object factories
+        cte_f29_factories
+    )\.py$
+    )
 plugins =
     pydantic.mypy
 


### PR DESCRIPTION
Instead of excluding `src/tests/`, only include individual files.