### PR TITLE
Improve Make tasks `clean-build`, `clean-pyc`, and `clean-test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,25 +45,24 @@ help:
 clean: clean-build clean-pyc clean-test ## remove all build, test, lint, coverage and Python artifacts
 
 clean-build: ## remove build artifacts
-	rm -rf .eggs/
-	rm -rf build/
-	rm -rf dist/
-	find . -name '*.egg-info' -exec rm -rf {} +
-	find . -name '*.egg' -exec rm -f {} +
+	${RM} -r .eggs/
+	${RM} -r build/
+	${RM} -r dist/
+	find . -iname '*.egg-info' -type d -prune -exec ${RM} -r {} \;
+	find . -iname '*.egg' -prune -exec ${RM} -r {} \;
 
 clean-pyc: ## remove Python file artifacts
-	find . -name '*.pyc' -exec rm -f {} +
-	find . -name '*.pyo' -exec rm -f {} +
-	find . -name '*~' -exec rm -f {} +
-	find . -name '__pycache__' -exec rm -rf {} +
+	find . -iname '*.py[cod]' -delete
+	find . -iname '*~' -exec ${RM} {} +
+	find . -iname __pycache__ -type d -prune -exec ${RM} -r {} \;
 
 clean-test: ## remove test, lint and coverage artifacts
-	rm -rf .cache/
-	rm -rf .tox/
-	rm -f .coverage
-	rm -rf htmlcov/
-	rm -rf test-reports/
-	rm -rf .mypy_cache/
+	${RM} -r .cache/
+	${RM} -r .tox/
+	${RM} .coverage
+	${RM} -r htmlcov/
+	${RM} -r test-reports/
+	${RM} -r .mypy_cache/
 
 install-dev: install-deps-dev
 install-dev: ## Install for development


### PR DESCRIPTION
This pull request includes updates to the `Makefile` to enhance the cleaning process by standardizing the use of the `RM` variable. The most important changes include replacing direct `rm` commands with `${RM}` and improving the `find` command options for better compatibility and performance.

Enhancements to cleaning process:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L48-R65): Replaced direct `rm` commands with `${RM}` to standardize the removal process and ensure consistency across different environments.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L48-R65): Improved `find` command options by using `-iname` for case-insensitive matching and `-prune` to optimize directory traversal.