### PR TITLE
Annotate method return types with `typing.Self` where appropriate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "pyOpenSSL>=24.0.0",
   "pytz>=2019.3",
   "signxml>=4.0.0",
+  "typing-extensions>=4.0.1",
 ]
 requires-python = ">=3.8, <3.11"
 authors = [

--- a/requirements.in
+++ b/requirements.in
@@ -19,3 +19,4 @@ pydantic==2.10.4
 pyOpenSSL==24.3.0
 pytz==2024.2
 signxml==4.0.3
+typing-extensions==4.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,6 +81,7 @@ sqlparse==0.5.0
     # via django
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   annotated-types
     #   asgiref
     #   pydantic

--- a/src/cl_sii/dte/data_models.py
+++ b/src/cl_sii/dte/data_models.py
@@ -24,6 +24,7 @@ from datetime import date, datetime
 from typing import Mapping, Optional, Sequence
 
 import pydantic
+from typing_extensions import Self
 
 import cl_sii.contribuyente.constants
 import cl_sii.rut.constants
@@ -854,7 +855,7 @@ class DteXmlData(DteDataL1):
     @pydantic.model_validator(mode='after')
     def validate_referencias_rut_otro_is_consistent_with_tipo_dte(
         self, info: pydantic.ValidationInfo
-    ) -> DteXmlData:
+    ) -> Self:
         referencias = self.referencias
         tipo_dte = self.tipo_dte
 
@@ -880,7 +881,7 @@ class DteXmlData(DteDataL1):
     @pydantic.model_validator(mode='after')
     def validate_referencias_rut_otro_is_consistent_with_emisor_rut(
         self, info: pydantic.ValidationInfo
-    ) -> DteXmlData:
+    ) -> Self:
         referencias = self.referencias
         emisor_rut = self.emisor_rut
 
@@ -900,7 +901,7 @@ class DteXmlData(DteDataL1):
         return self
 
     @pydantic.model_validator(mode='after')
-    def validate_referencias_codigo_ref_is_consistent_with_tipo_dte(self) -> DteXmlData:
+    def validate_referencias_codigo_ref_is_consistent_with_tipo_dte(self) -> Self:
         referencias = self.referencias
         tipo_dte = self.tipo_dte
 

--- a/src/cl_sii/rcv/data_models.py
+++ b/src/cl_sii/rcv/data_models.py
@@ -12,6 +12,7 @@ from datetime import date, datetime
 from typing import ClassVar, Optional
 
 import pydantic
+from typing_extensions import Self
 
 import cl_sii.dte.data_models
 from cl_sii.base.constants import SII_OFFICIAL_TZ
@@ -174,7 +175,7 @@ class RcvDetalleEntry:
         return v
 
     @pydantic.model_validator(mode='after')
-    def validate_rcv_kind_is_consistent_with_rc_estado_contable(self) -> RcvDetalleEntry:
+    def validate_rcv_kind_is_consistent_with_rc_estado_contable(self) -> Self:
         rcv_kind = self.RCV_KIND
         rc_estado_contable = self.RC_ESTADO_CONTABLE
 

--- a/src/cl_sii/rtc/data_models.py
+++ b/src/cl_sii/rtc/data_models.py
@@ -24,6 +24,7 @@ from datetime import date, datetime
 from typing import ClassVar, Mapping, Optional
 
 import pydantic
+from typing_extensions import Self
 
 from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.dte import data_models as dte_data_models
@@ -508,7 +509,7 @@ class CesionL1(CesionL0):
         return v
 
     @pydantic.model_validator(mode='after')
-    def validate_monto_cedido_does_not_exceed_dte_monto_total(self) -> CesionL1:
+    def validate_monto_cedido_does_not_exceed_dte_monto_total(self) -> Self:
         monto_cedido = self.monto_cedido
         dte_monto_total = self.dte_monto_total
 
@@ -705,7 +706,7 @@ class CesionL2(CesionL1):
         return v
 
     @pydantic.model_validator(mode='after')
-    def validate_dte_data_l2(self) -> CesionL2:
+    def validate_dte_data_l2(self) -> Self:
         dte_key = self.dte_key
         try:
             # Note: Delegate some validation to 'dte_data_models.DteDataL2'.

--- a/src/cl_sii/rtc/data_models_aec.py
+++ b/src/cl_sii/rtc/data_models_aec.py
@@ -10,6 +10,7 @@ from datetime import date, datetime
 from typing import ClassVar, Mapping, Optional, Sequence, Tuple
 
 import pydantic
+from typing_extensions import Self
 
 from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.dte import data_models as dte_data_models
@@ -342,7 +343,7 @@ class CesionAecXml:
         return v
 
     @pydantic.model_validator(mode='after')
-    def validate_fecha_cesion_dt_is_consistent_with_dte(self) -> CesionAecXml:
+    def validate_fecha_cesion_dt_is_consistent_with_dte(self) -> Self:
         fecha_cesion_dt = self.fecha_cesion_dt
         dte = self.dte
 
@@ -352,7 +353,7 @@ class CesionAecXml:
         return self
 
     @pydantic.model_validator(mode='after')
-    def validate_monto_cesion_does_not_exceed_dte_monto_total(self) -> CesionAecXml:
+    def validate_monto_cesion_does_not_exceed_dte_monto_total(self) -> Self:
         monto_cesion = self.monto_cesion
         dte = self.dte
 
@@ -365,7 +366,7 @@ class CesionAecXml:
         return self
 
     @pydantic.model_validator(mode='after')
-    def validate_fecha_ultimo_vencimiento_is_consistent_with_dte(self) -> CesionAecXml:
+    def validate_fecha_ultimo_vencimiento_is_consistent_with_dte(self) -> Self:
         fecha_ultimo_vencimiento = self.fecha_ultimo_vencimiento
         dte = self.dte
 
@@ -732,7 +733,7 @@ class AecXml:
     #     return v
 
     @pydantic.model_validator(mode='after')
-    def validate_dte_matches_cesiones_dtes(self) -> AecXml:
+    def validate_dte_matches_cesiones_dtes(self) -> Self:
         dte = self.dte
         cesiones = self.cesiones
 
@@ -751,7 +752,7 @@ class AecXml:
         return self
 
     @pydantic.model_validator(mode='after')
-    def validate_last_cesion_matches_some_fields(self) -> AecXml:
+    def validate_last_cesion_matches_some_fields(self) -> Self:
         field_validations: Sequence[Tuple[str, str]] = [
             # (AecXml field, CesionAecXml field):
             # Even though it seems reasonable to expect that the date in `fecha_firma_dt`
@@ -784,7 +785,7 @@ class AecXml:
     @pydantic.model_validator(mode='after')
     def validate_signature_value_and_signature_x509_cert_der_may_only_be_none_together(
         self,
-    ) -> AecXml:
+    ) -> Self:
         signature_value = self.signature_value
         signature_x509_cert_der = self.signature_x509_cert_der
 


### PR DESCRIPTION
> In general, if something returns `self`, […], you should use `Self` as the return annotation.

> You should not use `Self` as the return annotation if the method is not guaranteed to return an instance of a subclass when the class is subclassed […]