### PR TITLE
deps: Increase minimum version of Python package `Django` to 4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-django = ["Django>=2.2.24"]
+django = ["Django>=4.2"]
 django-filter = ["django-filter>=24.2"]
 djangorestframework = ["djangorestframework>=3.10.3,<3.16"]
 pydantic = ["pydantic>=2.0"]

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ backports-zoneinfo==0.2.1 ; python_version < "3.9" # Used by `djangorestframewor
 cryptography==44.0.0
 defusedxml==0.7.1
 django-filter>=24.2
-Django>=2.2.24
+Django>=4.2
 djangorestframework>=3.10.3,<3.16
 importlib-metadata==8.5.0
 jsonschema==4.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ cryptography==44.0.0
     #   signxml
 defusedxml==0.7.1
     # via -r requirements.in
-django==4.2.17
+django==4.2.18
     # via
     #   -r requirements.in
     #   django-filter


### PR DESCRIPTION
Update constraint for optional dependency `Django` from ≥ 2.2.24 to ≥ 4.2 to prevent compatibility issues.

Fixes: https://github.com/cordada/lib-cl-sii-python/security/dependabot/67