### PR TITLE
Python dependency sync check is never executed in CI/CD workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Check that compiled Python dependency manifests are up-to-date with their sources
         # FIXME: There are issues related to testing with multiple Python versions.
-        if: ${{ startsWith(matrix.python_version, '3.8.') }}
+        if: ${{ startsWith(steps.set_up_python.outputs.python-version, '3.8.') }}
         run: |
           source "$PYTHON_VIRTUALENV_ACTIVATE"
           make python-deps-sync-check


### PR DESCRIPTION
The step *“Check that compiled Python dependency manifests are up-to-date with their sources”* is supposed to run only for the lowest supported Python version (currently 3.8). However, commit 751adb045e99946adb1ea447e4344b4281d65900 from pull request https://github.com/cordada/lib-cl-sii-python/pull/748 inadvertently disabled this step for all Python versions because of an incorrect string comparison (`3.8.` is _not_ a substring of `3.8`).