### PR TITLE
deps: Update `packaging` from 24.1 to 24.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -86,7 +86,7 @@ mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements.txt
     #   black

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ lxml==5.3.1
     #   signxml
 marshmallow==3.22.0
     # via -r requirements.in
-packaging==24.1
+packaging==24.2
     # via marshmallow
 pycparser==2.22
     # via cffi


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/packaging/24.2/)
- [Release Notes](https://github.com/pypa/packaging/releases/tag/24.2)
- [Changelog](https://github.com/pypa/packaging/blob/24.2/CHANGELOG.rst#242---2024-11-08)
- [Commits](https://github.com/pypa/packaging/compare/24.1...24.2)

`packaging` versions <24.2 cause the following error when running `twine check --strict dist/*`:

> Checking `dist/cl_sii-0.43.0-py3-none-any.whl`:
>   ERROR    InvalidDistribution:
>     Invalid distribution metadata: unrecognized or malformed field 'license-file'