### PR TITLE
Release v0.45.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.44.0
+current_version = 0.45.0
 commit = True
 tag = False
 message = chore: Bump version from {current_version} to {new_version}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 # History
 
+## 0.45.0 (2025-03-24)
+
+- (PR #784, 2025-03-13) chore(deps): Bump the development-dependencies group with 8 updates
+- (PR #773, 2025-03-13) chore(deps): Bump django-filter from 24.3 to 25.1
+- (PR #774, 2025-03-17) chore(deps): Bump marshmallow from 3.22.0 to 3.26.1
+- (PR #776, 2025-03-17) chore(deps): Bump importlib-metadata from 8.5.0 to 8.6.1
+- (PR #787, 2025-03-24) Require Python ≥3.9
+
 ## 0.44.0 (2025-03-13)
 
 - (PR #783, 2025-03-13) deps: Update `packaging` from 24.1 to 24.2

--- a/src/cl_sii/__init__.py
+++ b/src/cl_sii/__init__.py
@@ -4,4 +4,4 @@ cl-sii Python lib
 
 """
 
-__version__ = '0.44.0'
+__version__ = '0.45.0'


### PR DESCRIPTION
- (PR #784, 2025-03-13) chore(deps): Bump the development-dependencies group with 8 updates
- (PR #773, 2025-03-13) chore(deps): Bump django-filter from 24.3 to 25.1
- (PR #774, 2025-03-17) chore(deps): Bump marshmallow from 3.22.0 to 3.26.1
- (PR #776, 2025-03-17) chore(deps): Bump importlib-metadata from 8.5.0 to 8.6.1
- (PR #787, 2025-03-24) Require Python ≥3.9