### PR TITLE
Add GitHub Actions workflow to release and deploy; Etc.

### DIFF
--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -8,6 +8,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - ready_for_review
 
 permissions:
   contents: read

--- a/.github/workflows/task-release-and-deploy.yaml
+++ b/.github/workflows/task-release-and-deploy.yaml
@@ -1,0 +1,75 @@
+# GitHub Actions Workflow for 'Release and Deploy' Task
+
+name: "Task: Release and Deploy"
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches: # Base reference
+      - develop
+
+permissions: {}
+
+jobs:
+  deploy:
+    name: Deploy
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') }}
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      CREATE_RELEASE_VCS_REVISION_ID: ${{ github.sha }} # Merge commit in base branch.
+      PREPARE_RELEASE_GITHUB_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
+      PREPARE_RELEASE_GITHUB_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+      PREPARE_RELEASE_GITHUB_VCS_REF: ${{ github.event.pull_request.head.ref }}
+      RELEASE_ASSIGNEE: ${{ github.event.pull_request.assignee.login }}
+      RELEASE_VCS_REF: refs/heads/master
+
+    steps:
+      - name: Check Out VCS Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ env.CREATE_RELEASE_VCS_REVISION_ID }}
+
+      - name: Prepare Git
+        run: |
+          echo 'Adding Git aliases…'
+          git config alias.publish \
+            'push --set-upstream origin HEAD'
+
+      - name: Prepare Pull Request for Deployment
+        run: |
+          create_release_vcs_branch_name="${PREPARE_RELEASE_GITHUB_VCS_REF:?}"
+          create_release_vcs_branch_name="${create_release_vcs_branch_name/release/deploy}"
+          echo "Creating release creation VCS branch '$create_release_vcs_branch_name'…"
+          git checkout -b "${create_release_vcs_branch_name:?}" --
+          git publish --verbose
+
+          create_release_vcs_ref="refs/heads/${create_release_vcs_branch_name:?}"
+          echo "CREATE_RELEASE_VCS_REF=${create_release_vcs_ref:?}" >> "$GITHUB_ENV"
+
+          create_release_github_pull_request_title="${PREPARE_RELEASE_GITHUB_PULL_REQUEST_TITLE:?}"
+          create_release_github_pull_request_title="deploy ${create_release_github_pull_request_title,,}"
+          create_release_github_pull_request_title="${create_release_github_pull_request_title@u}"
+          echo "CREATE_RELEASE_GITHUB_PULL_REQUEST_TITLE=${create_release_github_pull_request_title:?}" >> "$GITHUB_ENV"
+
+          create_release_github_pull_request_description="Ref: ${PREPARE_RELEASE_GITHUB_PULL_REQUEST_HTML_URL:?}"
+          echo "CREATE_RELEASE_GITHUB_PULL_REQUEST_DESCRIPTION=${create_release_github_pull_request_description:?}" >> "$GITHUB_ENV"
+
+      - name: Create GitHub Pull Request for Deployment
+        run: |
+          gh pr create \
+            --base "$RELEASE_VCS_REF" \
+            --head "$CREATE_RELEASE_VCS_REF" \
+            --draft \
+            --title "$CREATE_RELEASE_GITHUB_PULL_REQUEST_TITLE" \
+            --body "$CREATE_RELEASE_GITHUB_PULL_REQUEST_DESCRIPTION" \
+            --assignee "$RELEASE_ASSIGNEE" \
+            --label 'task' \
+            --label 'kind: deploy'
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- Add GitHub Actions workflow to release and deploy.
- Trigger Git Commit Linter when a draft PR is ready for review.

  GitHub Actions does not create a new workflow run for events triggered
  by the GitHub Actions authentication token (`secrets.GITHUB_TOKEN`),
  which results in the Git Commit Linter’s workflow not being triggered
  when pull requests are created using GitHub Actions.
  
  This commit adds `ready_for_review` to the event types that trigger the
  GitHub Actions workflow 'Git Commit Linter' so that it runs for
  pull requests created using GitHub Actions when they are marked as
  ready for review by a user.
  
  From [Automatic token authentication](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication):
  
  > When you use the repository's `GITHUB_TOKEN` to perform tasks, events
  > triggered by the `GITHUB_TOKEN`, with the exception of
  > `workflow_dispatch` and `repository_dispatch`, will not create a new
  > workflow run. This prevents you from accidentally creating recursive
  > workflow runs. For example, if a workflow run pushes code using the
  > repository's `GITHUB_TOKEN`, a new workflow will not run even when the
  > repository contains a workflow configured to run when `push` events occur.