### PR TITLE
deps: Install Python package `setuptools`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -205,4 +205,6 @@ zipp==3.20.2
 pip==24.2
     # via pip-tools
 setuptools==80.9.0
-    # via pip-tools
+    # via
+    #   -c requirements.txt
+    #   pip-tools

--- a/requirements.in
+++ b/requirements.in
@@ -18,5 +18,6 @@ marshmallow==3.26.1
 pydantic==2.11.7
 pyOpenSSL==25.1.0
 pytz==2025.2
+setuptools==80.9.0
 signxml==4.0.5
 typing-extensions==4.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,3 +80,7 @@ typing-inspection==0.4.0
     # via pydantic
 zipp==3.20.2
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==80.9.0
+    # via -r requirements.in


### PR DESCRIPTION
> Easily download, build, install, upgrade, and uninstall Python packages

- [Web Site](https://setuptools.pypa.io/)
- [VCS Repository](https://github.com/pypa/setuptools.git)
- [Documentation](https://setuptools.pypa.io/)
- [Software Repository](https://pypi.org/project/setuptools/)

**Note**: This package is already installed as a transitive dependency, but it is also a direct dependency (e.g. `setup.py` imports `setuptools`), and direct dependencies should be in `requirements.in` (and `requirements.txt`).