### PR TITLE
deps: Uninstall Python package `wheel`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@
 [build-system]
 requires = [
   "setuptools==80.9.0",
-  "wheel==0.45.1",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -18,4 +18,3 @@ types-jsonschema==4.24.0.20250528
 types-lxml==2025.3.30
 types-pytz==2025.2.0.20250516
 types-setuptools==80.9.0.20250529
-wheel==0.45.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -193,9 +193,7 @@ virtualenv==20.31.2
 webencodings==0.5.1
     # via bleach
 wheel==0.45.1
-    # via
-    #   -r requirements-dev.in
-    #   pip-tools
+    # via pip-tools
 zipp==3.20.2
     # via
     #   -c requirements.txt


### PR DESCRIPTION
From [Wheel's documentation](https://github.com/pypa/wheel/blob/fc8cb416/README.rst):

> ## Historical note
>
> This project used to contain the implementation of the [setuptools](https://pypi.org/project/setuptools/) `bdist_wheel` command, but as of setuptools v70.1, it no longer needs `wheel` installed for that to work. Thus, you should install this **only** if you intend to use the `wheel` command line tool!