### PR TITLE
rcv: Add RcTipoCompra enum to represent "Tipo de Compra" in RCV

### DIFF
--- a/src/cl_sii/rcv/constants.py
+++ b/src/cl_sii/rcv/constants.py
@@ -98,6 +98,19 @@ class RcEstadoContable(enum.Enum):
 
 
 @enum.unique
+class RcTipoCompra(enum.Enum):
+    """
+    Enum of "Tipo de Compra" for the RCV domain.
+    """
+
+    DEL_GIRO = "DEL_GIRO"
+    """Del Giro"""
+
+    NO_CORRESPONDE_INCLUIR = "NO_CORRESPONDE_INCLUIR"
+    """No corresponde incluir"""
+
+
+@enum.unique
 class RcvTipoDocto(enum.IntEnum):
     """
     Enum of "Tipo de Documento" for the RCV domain.

--- a/src/tests/test_rcv_constants.py
+++ b/src/tests/test_rcv_constants.py
@@ -2,7 +2,7 @@ import unittest
 
 from cl_sii.dte.constants import TipoDte  # noqa: F401
 from cl_sii.rcv import constants  # noqa: F401
-from cl_sii.rcv.constants import RcEstadoContable, RcvKind, RcvTipoDocto  # noqa: F401
+from cl_sii.rcv.constants import RcEstadoContable, RcTipoCompra, RcvKind, RcvTipoDocto  # noqa: F401
 
 
 class RcvKindTest(unittest.TestCase):
@@ -46,6 +46,20 @@ class RcEstadoContableTest(unittest.TestCase):
 
     def test_values_type(self) -> None:
         self.assertSetEqual({type(x.value) for x in RcEstadoContable}, {str})
+
+
+class RcTipoCompraTest(unittest.TestCase):
+    def test_members(self) -> None:
+        self.assertSetEqual(
+            {x for x in RcTipoCompra},
+            {
+                RcTipoCompra.DEL_GIRO,
+                RcTipoCompra.NO_CORRESPONDE_INCLUIR,
+            },
+        )
+
+    def test_values_type(self) -> None:
+        self.assertSetEqual({type(x.value) for x in RcTipoCompra}, {str})
 
 
 class RcvTipoDoctoTest(unittest.TestCase):


### PR DESCRIPTION
Ref: https://app.shortcut.com/cordada/story/16109/