### PR TITLE
rcv: Extend RcTipoCompra enum with new purchase types

### DIFF
--- a/src/cl_sii/rcv/constants.py
+++ b/src/cl_sii/rcv/constants.py
@@ -106,8 +106,23 @@ class RcTipoCompra(enum.Enum):
     DEL_GIRO = "DEL_GIRO"
     """Del Giro"""
 
+    SUPERMERCADOS = "SUPERMERCADOS"
+    """Supermercados"""
+
+    BIENES_RAICES = "BIENES_RAICES"
+    """Bienes Raíces"""
+
+    ACTIVO_FIJO = "ACTIVO_FIJO"
+    """Activo Fijo"""
+
+    IVA_USO_COMUN = "IVA_USO_COMUN"
+    """IVA Uso Común"""
+
+    IVA_NO_RECUPERABLE = "IVA_NO_RECUPERABLE"
+    """IVA no Recuperable"""
+
     NO_CORRESPONDE_INCLUIR = "NO_CORRESPONDE_INCLUIR"
-    """No corresponde incluir"""
+    """No Corresp. Incluir"""
 
 
 @enum.unique

--- a/src/tests/test_rcv_constants.py
+++ b/src/tests/test_rcv_constants.py
@@ -54,6 +54,11 @@ class RcTipoCompraTest(unittest.TestCase):
             {x for x in RcTipoCompra},
             {
                 RcTipoCompra.DEL_GIRO,
+                RcTipoCompra.SUPERMERCADOS,
+                RcTipoCompra.BIENES_RAICES,
+                RcTipoCompra.ACTIVO_FIJO,
+                RcTipoCompra.IVA_USO_COMUN,
+                RcTipoCompra.IVA_NO_RECUPERABLE,
                 RcTipoCompra.NO_CORRESPONDE_INCLUIR,
             },
         )


### PR DESCRIPTION
- Added new types:
    - SUPERMERCADOS
    - BIENES_RAICES
    - ACTIVO_FIJO
    - IVA_USO_COMUN
    - IVA_NO_RECUPERABLE.

Ref: https://app.shortcut.com/cordada/story/16109/