### PR TITLE
rut: Constant `RUT_DIGITS_MIN_VALUE` should be for the whole range of RUTs

### DIFF
--- a/src/cl_sii/rut/constants.py
+++ b/src/cl_sii/rut/constants.py
@@ -19,7 +19,7 @@ RUT_CANONICAL_MIN_LENGTH = 3
 """RUT min length for canonical format."""
 RUT_DIGITS_MAX_VALUE = 99999999
 """RUT digits max value."""
-RUT_DIGITS_MIN_VALUE = 50000000
+RUT_DIGITS_MIN_VALUE = 1
 """RUT digits min value."""
 
 SII_CERT_TITULAR_RUT_OID = cryptography.x509.oid.ObjectIdentifier("1.3.6.1.4.1.8321.1")

--- a/src/tests/test_rut_constants.py
+++ b/src/tests/test_rut_constants.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import unittest
+
+from cl_sii.rut import constants
+
+
+class RutDigitsConstantsTestCase(unittest.TestCase):
+    def test_min_value(self) -> None:
+        min_rut_digits = constants.RUT_DIGITS_MIN_VALUE
+
+        self.assertLessEqual(min_rut_digits, constants.RUT_DIGITS_MAX_VALUE)
+
+    def test_max_value(self) -> None:
+        max_rut_digits = constants.RUT_DIGITS_MAX_VALUE
+
+        self.assertGreaterEqual(max_rut_digits, constants.RUT_DIGITS_MIN_VALUE)
+
+    def test_persona_juridica_min_value(self) -> None:
+        min_rut_digits = constants.PERSONA_JURIDICA_MIN_RUT_DIGITS
+
+        self.assertGreaterEqual(min_rut_digits, constants.RUT_DIGITS_MIN_VALUE)
+        self.assertLessEqual(min_rut_digits, constants.RUT_DIGITS_MAX_VALUE)


### PR DESCRIPTION
The value `50000000` is the minimum RUT digits for a "Persona Jurídica", not for the whole range of RUT.

If the minimum RUT digits for a "Persona Jurídica" is desired, use `PERSONA_JURIDICA_MIN_RUT_DIGITS` instead of `RUT_DIGITS_MIN_VALUE`.

⚠️ Breaking change: The range of possible return values of `Rut.random()` will be expanded because it uses `RUT_DIGITS_MIN_VALUE`.

Fixes: https://github.com/cordada/lib-cl-sii-python/issues/96