### PR TITLE
extras: Add option to validate RUT DV to Django model field `RutField`

### DIFF
--- a/src/tests/test_extras_dj_model_fields.py
+++ b/src/tests/test_extras_dj_model_fields.py
@@ -1,6 +1,8 @@
 import unittest
+import unittest.mock
 
-import django.db.models  # noqa: F401
+import django.core.exceptions
+import django.db.models
 
 from cl_sii.extras.dj_model_fields import Rut, RutField
 
@@ -8,13 +10,19 @@ from cl_sii.extras.dj_model_fields import Rut, RutField
 class RutFieldTest(unittest.TestCase):
     valid_rut_canonical: str
     valid_rut_instance: Rut
+    valid_rut_canonical_with_invalid_dv: str
     valid_rut_verbose_leading_zero_lowercase: str
+    mock_model_instance: django.db.models.Model
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.valid_rut_canonical = '60803000-K'
         cls.valid_rut_instance = Rut(cls.valid_rut_canonical)
+        cls.valid_rut_canonical_with_invalid_dv = '60803000-0'
         cls.valid_rut_verbose_leading_zero_lowercase = '060.803.000-k'
+        cls.mock_model_instance = unittest.mock.create_autospec(
+            django.db.models.Model, instance=True
+        )
 
     def test_get_prep_value_of_canonical_str(self) -> None:
         prepared_value = RutField().get_prep_value(self.valid_rut_canonical)
@@ -34,3 +42,33 @@ class RutFieldTest(unittest.TestCase):
     def test_get_prep_value_of_None(self) -> None:
         prepared_value = RutField().get_prep_value(None)
         self.assertIsNone(prepared_value)
+
+    def test_clean_value_of_rut_str_with_invalid_dv_if_validated(self) -> None:
+        rut_field = RutField(validate_dv=True)
+        with self.assertRaises(django.core.exceptions.ValidationError) as cm:
+            rut_field.clean(self.valid_rut_canonical_with_invalid_dv, self.mock_model_instance)
+        self.assertEqual(cm.exception.code, 'invalid_dv')
+
+    def test_clean_value_of_rut_str_with_invalid_dv_if_not_validated(self) -> None:
+        rut_field = RutField(validate_dv=False)
+        cleaned_value = rut_field.clean(
+            self.valid_rut_canonical_with_invalid_dv, self.mock_model_instance
+        )
+        self.assertIsInstance(cleaned_value, Rut)
+        self.assertEqual(cleaned_value.canonical, self.valid_rut_canonical_with_invalid_dv)
+
+    def test_deconstruct_without_options(self) -> None:
+        name, path, args, kwargs = RutField().deconstruct()
+        self.assertEqual(path, 'cl_sii.extras.dj_model_fields.RutField')
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {})
+
+    def test_deconstruct_with_option_validate_dv_enabled(self) -> None:
+        name, path, args, kwargs = RutField(validate_dv=True).deconstruct()
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {'validate_dv': True})
+
+    def test_deconstruct_with_option_validate_dv_disabled(self) -> None:
+        name, path, args, kwargs = RutField(validate_dv=False).deconstruct()
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {})


### PR DESCRIPTION
In Django model field `RutField`, add an option to validate that a RUT's "digito verificador" is correct. The option is disabled by default, so it does not break backward compatibility.