### PR TITLE
Release v0.54.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.53.0
+current_version = 0.54.0
 commit = True
 tag = False
 message = chore: Bump version from {current_version} to {new_version}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 # History
 
+## 0.54.0 (2025-09-09)
+
+- (PR #871, 2025-09-09) rut: Use class variables for exception messages raised by `Rut`
+- (PR #873, 2025-09-09) chore(deps): Bump the python-development group across 1 directory with 2 updates
+- (PR #874, 2025-09-09) extras: Add option to validate RUT DV to Django model field `RutField`
+- (PR #875, 2025-09-09) extras: Refactor `dj_form_fields.RutField.to_python()`
+- (PR #872, 2025-09-09) chore(deps): Bump django from 4.2.23 to 4.2.24
+
 ## 0.53.0 (2025-09-02)
 
 - (PR #862, 2025-08-28) chore(deps): Bump the github-actions-production group with 5 updates

--- a/src/cl_sii/__init__.py
+++ b/src/cl_sii/__init__.py
@@ -4,4 +4,4 @@ cl-sii Python lib
 
 """
 
-__version__ = '0.53.0'
+__version__ = '0.54.0'


### PR DESCRIPTION
## Changes

- (PR #871, 2025-09-09) rut: Use class variables for exception messages raised by `Rut`
- (PR #873, 2025-09-09) chore(deps): Bump the python-development group across 1 directory with 2 updates
- (PR #874, 2025-09-09) extras: Add option to validate RUT DV to Django model field `RutField`
- (PR #875, 2025-09-09) extras: Refactor `dj_form_fields.RutField.to_python()`
- (PR #872, 2025-09-09) chore(deps): Bump django from 4.2.23 to 4.2.24