### PR TITLE
Release v0.56.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.55.0
+current_version = 0.56.0
 commit = True
 tag = False
 message = chore: Bump version from {current_version} to {new_version}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## 0.56.0 (2025-09-10)
+
+- (PR #883, 2025-09-10) extras: Add more tests for Django form field for `Rut`
+- (PR #884, 2025-09-10) extras: Improve Django filters `FILTER_FOR_DBFIELD_DEFAULTS`
+- (PR #882, 2025-09-10) extras: Django model field `RutField` does not validate DV of `Rut`
+- (PR #885, 2025-09-10) deps: Update `cryptography` from 45.0.4 to 45.0.7
+
 ## 0.55.0 (2025-09-10)
 
 - (PR #878, 2025-09-10) extras: Improve Django filter for `Rut`

--- a/src/cl_sii/__init__.py
+++ b/src/cl_sii/__init__.py
@@ -4,4 +4,4 @@ cl-sii Python lib
 
 """
 
-__version__ = '0.55.0'
+__version__ = '0.56.0'


### PR DESCRIPTION
## Changes

- (PR #883, 2025-09-10) extras: Add more tests for Django form field for `Rut`
- (PR #884, 2025-09-10) extras: Improve Django filters `FILTER_FOR_DBFIELD_DEFAULTS`
- (PR #882, 2025-09-10) extras: Django model field `RutField` does not validate DV of `Rut`
- (PR #885, 2025-09-10) deps: Update `cryptography` from 45.0.4 to 45.0.7