### PR TITLE
cte: Add parser for "Propiedades y Bienes Raíces"

### DIFF
--- a/src/cl_sii/cte/data_models.py
+++ b/src/cl_sii/cte/data_models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import date
+from decimal import Decimal
 from typing import Optional
 
 import pydantic
@@ -86,3 +87,89 @@ class TaxpayerData:
 class LastFiledDocument:
     name: str
     date: date
+
+
+@pydantic.dataclasses.dataclass(
+    frozen=True,
+    config=pydantic.ConfigDict(
+        arbitrary_types_allowed=True,
+        extra='forbid',
+    ),
+)
+class TaxpayerProperties:
+    """
+    Propiedades y Bienes Raíces (3)
+    """
+
+    properties: Sequence[Property]
+
+
+@pydantic.dataclasses.dataclass(
+    frozen=True,
+)
+class Property:
+    commune: Optional[str]
+    """
+    Comuna
+    """
+    role: Optional[str]
+    """
+    Rol
+    """
+    address: Optional[str]
+    """
+    Dirección
+    """
+    purpose: Optional[str]
+    """
+    Destino
+    """
+    fiscal_valuation: Optional[Decimal]
+    """
+    Avalúo Fiscal
+    """
+    overdue_installments: Optional[bool]
+    """
+    Cuotas vencidas por pagar
+    """
+    current_installments: Optional[bool]
+    """
+    Cuotas vigentes por pagar
+    """
+    condition: Optional[str]
+    """
+    Condición
+    """
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    @pydantic.field_validator('fiscal_valuation', mode='before')
+    @classmethod
+    def parse_fiscal_valuation(cls, v: Optional[str]) -> Optional[Decimal]:
+        if isinstance(v, str):
+            v = v.replace('.', '').replace(',', '.')
+            return Decimal(v)
+        return v
+
+    @pydantic.field_validator('commune', 'role', 'address', 'purpose', 'condition')
+    @classmethod
+    def parse_str_fields(cls, v: Optional[str]) -> Optional[str]:
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v
+
+    @pydantic.field_validator('current_installments', 'overdue_installments', mode='before')
+    @classmethod
+    def parse_boolean_fields(cls, v: Optional[str | bool]) -> Optional[bool]:
+        if isinstance(v, str):
+            if v == 'NO':
+                return False
+            elif v == 'SI':
+                return True
+            else:
+                return None
+        if isinstance(v, bool):
+            return v
+        return None

--- a/src/tests/test_cte_parsers.py
+++ b/src/tests/test_cte_parsers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date
+from decimal import Decimal
 from unittest import TestCase
 
 from cl_sii.cte import data_models, parsers
@@ -42,7 +43,7 @@ class ParsersTest(TestCase):
             )
             self.assertEqual(result, expected_obj)
 
-        with self.subTest("Parsing emtpy content"):
+        with self.subTest("Parsing empty content"):
             with self.assertRaises(ValueError) as assert_raises_cm:
                 parsers.parse_taxpayer_provided_info("")
 
@@ -105,3 +106,53 @@ class ParsersTest(TestCase):
                 tax_observations=None,
             )
             self.assertEqual(result, expected_obj)
+
+    def test_parse_taxpayer_properties(self) -> None:
+        html_content = read_test_file_str_utf8('test_data/sii-cte/cte_empty_f29.html')
+
+        with self.subTest("Parsing ok"):
+            result = parsers.parse_taxpayer_properties(html_content)
+            expected_obj = data_models.TaxpayerProperties(
+                properties=[
+                    data_models.Property(
+                        commune="LAS CONDES",
+                        role="123-4",
+                        address="Av. Apoquindo 1234",
+                        purpose="HABITACIONAL",
+                        fiscal_valuation=Decimal('46550332'),
+                        overdue_installments=True,
+                        current_installments=True,
+                        condition="AFECTO",
+                    ),
+                    data_models.Property(
+                        commune="PROVIDENCIA",
+                        role="567-8",
+                        address="Calle 10 #456",
+                        purpose="COMERCIAL",
+                        fiscal_valuation=None,
+                        overdue_installments=False,
+                        current_installments=False,
+                        condition="EXENTO",
+                    ),
+                    data_models.Property(
+                        commune="ÑUÑOA",
+                        role=None,
+                        address=None,
+                        purpose="INDUSTRIAL",
+                        fiscal_valuation=Decimal('78456789'),
+                        overdue_installments=False,
+                        current_installments=False,
+                        condition="AFECTO",
+                    ),
+                ],
+            )
+            self.assertEqual(result, expected_obj)
+
+        with self.subTest("Parsing empty content"):
+            with self.assertRaises(ValueError) as assert_raises_cm:
+                parsers.parse_taxpayer_properties("")
+
+            self.assertEqual(
+                assert_raises_cm.exception.args,
+                ("Could not find taxpayer information table in HTML",),
+            )

--- a/src/tests/test_data/sii-cte/cte_empty_f29.html
+++ b/src/tests/test_data/sii-cte/cte_empty_f29.html
@@ -220,11 +220,36 @@
         <td width="10%"><span class="textof">Cuotas vigentes por pagar</span></td>
         <td width="13%"><span class="textof">Condición<br>(4)</span></td>
       </tr>
-
-
+      <!-- MOCK PROPERTY ROWS -->
       <tr>
-        <td colspan="8" class="centeralign"><span class="textof">- No se registra información para este RUT -</span>
-        </td>
+        <td>LAS CONDES</td>
+        <td>123-4</td>
+        <td>Av. Apoquindo 1234</td>
+        <td>HABITACIONAL</td>
+        <td>46.550.332</td>
+        <td>SI</td>
+        <td>SI</td>
+        <td>AFECTO</td>
+      </tr>
+      <tr>
+        <td>PROVIDENCIA</td>
+        <td>567-8</td>
+        <td>Calle 10 #456</td>
+        <td>COMERCIAL</td>
+        <td></td>
+        <td>NO</td>
+        <td>NO</td>
+        <td>EXENTO</td>
+      </tr>
+      <tr>
+        <td>ÑUÑOA</td>
+        <td></td>
+        <td></td>
+        <td>INDUSTRIAL</td>
+        <td>78.456.789</td>
+        <td>NO</td>
+        <td>NO</td>
+        <td>AFECTO</td>
       </tr>
 
       <tr>


### PR DESCRIPTION
- Implemented `parse_taxpayer_properties` to parse property table from CTE HTML.
- Added `Property` and `TaxpayerProperties` data models.
- Created tests to validate parser functionality with sample HTML input.

Ref: https://app.shortcut.com/cordada/story/16536/